### PR TITLE
Fix uv venv failing to find PyGObject system bindings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,16 @@ dependencies = [
 ]
 
 [project.scripts]
-nirimod = "nirimod.main:main"
+nirimod = "nirimod.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["nirimod"]
 
 [tool.ruff]
 ignore = ["E402"]
+
+[tool.uv]
+python-preference = "system"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Feature

This PR allows execution of

```bash
uvx git+https://github.com/srinivasr/nirimod
```

If system has all dependencies it simply runs.

## Summary

- Set `python-preference = "system"` in `[tool.uv]` so uv uses the system Python interpreter instead of its own managed copy. Without this, the venv points at a separate site-packages tree that does not contain PyGObject or the GTK4/libadwaita introspection bindings, causing an immediate startup failure.
- Fix the `[project.scripts]` entrypoint from `nirimod.main:main` to `nirimod.__main__:main`, matching the actual module name.

## Context

`uv` downloads and manages its own Python builds by default. These managed interpreters have their own `lib/python3.x/site-packages` directory, which is completely separate from `/usr/lib64/python3.x/site-packages` where distro packages like `python3-gobject` install. As a result, `import gi` fails even though the system package is installed. Telling uv to prefer the system interpreter solves this without requiring users to manually pass flags.

## Test plan

- [ ] `rm -rf .venv && uv venv --system-site-packages && uv sync`
- [ ] `uv run nirimod` launches without the PyGObject import error
- [ ] Verify the app window appears and is functional