### PR TITLE
feat: add Nix flake for NixOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ __pycache__/
 # NiriMod Temporary Files
 *.kdl.bak
 *.kdl.tmp
+
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "A polished GTK4/libadwaita GUI configurator for the niri Wayland compositor";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        default = pkgs.callPackage ./package.nix { };
+      });
+
+      overlays.default = final: prev: {
+        nirimod = final.callPackage ./package.nix { };
+      };
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/nirimod";
+        };
+      });
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  python3Packages,
+  wrapGAppsHook4,
+  gtk4,
+  libadwaita,
+  gdk-pixbuf,
+  gobject-introspection,
+  hicolor-icon-theme,
+  desktop-file-utils,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "nirimod";
+  version = "0.1.0";
+
+  pyproject = true;
+
+  src = lib.cleanSource ./.;
+  # For nixpkgs: replace with fetchFromGitHub pointing to a release tag:
+  # src = fetchFromGitHub {
+  #   owner = "srinivasr";
+  #   repo = "nirimod";
+  #   tag = "v${finalAttrs.version}";
+  #   hash = "sha256-...";
+  # };
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    gobject-introspection
+    desktop-file-utils
+  ];
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    gdk-pixbuf
+    hicolor-icon-theme
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+  ];
+
+  postInstall = ''
+    install -Dm644 data/nirimod.svg $out/share/icons/hicolor/scalable/apps/nirimod.svg
+
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/io.github.nirimod.desktop << EOF
+    [Desktop Entry]
+    Version=1.0
+    Name=NiriMod
+    GenericName=Compositor Settings
+    Comment=GUI Configuration Manager for the Niri Wayland Compositor
+    Exec=nirimod
+    Icon=nirimod
+    Terminal=false
+    Type=Application
+    Categories=Utility;Settings;DesktopSettings;
+    Keywords=compositor;windowmanager;wayland;niri;settings;config;
+    StartupNotify=true
+    StartupWMClass=nirimod
+    EOF
+  '';
+
+  meta = {
+    description = "A polished GTK4/libadwaita GUI configurator for the niri Wayland compositor";
+    homepage = "https://github.com/srinivasr/nirimod";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "nirimod";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
### Summary

This PR adds a Nix flake (flake.nix + package.nix) so that NixOS users can install and run NiriMod without manual dependency setup.  

### Usage                                                                                             
                                                                                                     
```bash                                                                                               
 # Run directly from GitHub                                                                          
 nix run github:srinivasr/nirimod                                                                    
                                                                                                     
 # Install to user profile                                                                           
 nix profile install github:srinivasr/nirimod                                                        
                                                                                                     
 # Use as a flake input                                                                              
 inputs.nirimod.url = "github:srinivasr/nirimod";                                                    
```

 ### Notes                                                            
                                                                                                       
1. License discrepancy: pyproject.toml declares GPL-3.0-or-later but the LICENSE file is MIT. The flake uses MIT per the LICENSE file. You may want to align these.                                     
2. No git tags: For a future nixpkgs submission, release tags (v0.1.0) are needed. The package.nix includes a commented-out fetchFromGitHub block ready for that.                                        
3. No changes to existing functionality — this is purely additive. The install.sh flow and all existing code remain untouched.        