### PR TITLE
Fix window rule raw regex and screencast serialization

### DIFF
--- a/nirimod/kdl_parser.py
+++ b/nirimod/kdl_parser.py
@@ -34,7 +34,9 @@ class KdlNode:
     trailing_trivia: str = ""
     children_trailing_trivia: str = ""
     source_file: Path | None = field(default=None, compare=False, repr=False)
-    _removed_children: dict[str, tuple[int, "KdlNode"]] = field(default_factory=dict, compare=False, repr=False)
+    _removed_children: dict[str, tuple[int, "KdlNode"]] = field(
+        default_factory=dict, compare=False, repr=False
+    )
 
     def get_child(self, name: str) -> "KdlNode | None":
         for c in reversed(self.children):
@@ -205,6 +207,16 @@ def _lex(text: str) -> list[tuple[str, str]]:
         # plain token (identifier, number, keyword)
         j = i
         while j < n and text[j] not in ' \t\r\n;{}"\\':
+            # Property values can be written as raw strings, e.g.
+            # title=r#"^notificationtoasts_\d+_desktop$"#. Stop after the
+            # '=' so the raw-string lexer below can preserve backslashes.
+            if text[j] == "=" and j + 1 < n and text[j + 1] == "r":
+                k = j + 2
+                while k < n and text[k] == "#":
+                    k += 1
+                if k < n and text[k] == '"':
+                    j += 1
+                    break
             if text[j] == "/" and j + 1 < n and text[j + 1] in "-/*":
                 break
             j += 1
@@ -439,6 +451,7 @@ def _resolve_includes(
         if not target.exists():
             if not optional:
                 import warnings
+
                 warnings.warn(f"nirimod: included file not found: {target}")
             continue
 
@@ -511,7 +524,7 @@ def save_niri_config_multi(
 
     # Rebuild config.kdl in the original node order (include lines stay where
     # the user put them rather than getting hoisted to the top).
-    _LARGE = 10 ** 9
+    _LARGE = 10**9
     primary_items: list[tuple[int, KdlNode]] = []
     for inc_node, _ in include_slots:
         primary_items.append((getattr(inc_node, "_primary_order", _LARGE), inc_node))
@@ -632,7 +645,12 @@ def _write_node(node: KdlNode, indent: int = 0) -> str:
 
             for child in node.children:
                 child_str = _write_node(child, indent + 1)
-                if res and not res.endswith("\n") and child_str and not child_str.startswith("\n"):
+                if (
+                    res
+                    and not res.endswith("\n")
+                    and child_str
+                    and not child_str.startswith("\n")
+                ):
                     res += "\n"
                 res += child_str
 
@@ -658,7 +676,9 @@ def _write_node(node: KdlNode, indent: int = 0) -> str:
         return res
 
     elif node.trailing_trivia:
-        if not node.trailing_trivia[0].isspace() and not node.trailing_trivia.startswith("\n"):
+        if not node.trailing_trivia[
+            0
+        ].isspace() and not node.trailing_trivia.startswith("\n"):
             res += " "
         res += node.trailing_trivia
 
@@ -677,8 +697,13 @@ def write_kdl(nodes: list[KdlNode]) -> str:
         node_str = _write_node(n)
         if getattr(n, "eof_trivia", None):
             node_str += getattr(n, "eof_trivia")
-            
-        if res and not res.endswith("\n") and node_str and not node_str.startswith("\n"):
+
+        if (
+            res
+            and not res.endswith("\n")
+            and node_str
+            and not node_str.startswith("\n")
+        ):
             res += "\n"
         res += node_str
 
@@ -735,7 +760,10 @@ def remove_child(parent: KdlNode, child_name: str) -> None:
     if existing:
         if not hasattr(parent, "_removed_children"):
             parent._removed_children = {}
-        parent._removed_children[child_name] = (parent.children.index(existing), existing)
+        parent._removed_children[child_name] = (
+            parent.children.index(existing),
+            existing,
+        )
         parent.children.remove(existing)
 
 
@@ -753,7 +781,10 @@ def set_node_flag(parent: KdlNode, flag_name: str, enabled: bool) -> None:
     elif not enabled and existing is not None:
         if not hasattr(parent, "_removed_children"):
             parent._removed_children = {}
-        parent._removed_children[flag_name] = (parent.children.index(existing), existing)
+        parent._removed_children[flag_name] = (
+            parent.children.index(existing),
+            existing,
+        )
         parent.children.remove(existing)
 
 

--- a/nirimod/pages/window_rules.py
+++ b/nirimod/pages/window_rules.py
@@ -6,13 +6,15 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Adw, Gtk, GLib, Pango
+from gi.repository import Adw, Gtk, GLib
 
 from nirimod.kdl_parser import KdlNode, KdlRawString
-from nirimod.pages.base import BasePage, make_toolbar_page
+from nirimod.pages.base import BasePage
 
 
 # ── Human-readable labels ────────────────────────────────────────────────────
+
+SCREENCAST_BLOCK_KEY = "block-out-from"
 
 BOOL_MATCH_LABELS = {
     "is-active": "Is Active",
@@ -25,7 +27,7 @@ BOOL_ACTION_LABELS = {
     "open-maximized": "Open Maximized",
     "open-fullscreen": "Open Fullscreen",
     "open-floating": "Open Floating",
-    "block-out-from-screencast": "Block from Screencast",
+    SCREENCAST_BLOCK_KEY: "Block from Screencast",
     "draw-border-with-background": "Draw Border with Background",
     "clip-to-geometry": "Clip to Geometry",
     "prefer-no-csd": "Prefer No CSD",
@@ -49,8 +51,28 @@ STR_ACTION_LABELS = {
 
 LAYER_BOOL_ACTION_LABELS = {
     "place-within-backdrop": "Place Within Backdrop",
-    "block-out-from-screencast": "Block from Screencast",
+    SCREENCAST_BLOCK_KEY: "Block from Screencast",
 }
+
+
+def _bool_action_active(rule: KdlNode | None, key: str) -> bool:
+    if rule is None:
+        return False
+    if key != SCREENCAST_BLOCK_KEY:
+        return rule.get_child(key) is not None
+
+    legacy = rule.get_child("block-out-from-screencast")
+    if legacy is not None:
+        return True
+
+    node = rule.get_child(SCREENCAST_BLOCK_KEY)
+    return node is not None and bool(node.args) and node.args[0] == "screencast"
+
+
+def _bool_action_node(key: str) -> KdlNode:
+    if key == SCREENCAST_BLOCK_KEY:
+        return KdlNode(SCREENCAST_BLOCK_KEY, args=["screencast"])
+    return KdlNode(key, args=[True])
 
 
 def _rule_summary(rule: KdlNode) -> tuple[str, str]:
@@ -100,6 +122,7 @@ def _layer_rule_summary(rule: KdlNode) -> tuple[str, str]:
 
 
 # ── Page ─────────────────────────────────────────────────────────────────────
+
 
 class WindowRulesPage(BasePage):
     def build(self) -> Gtk.Widget:
@@ -234,7 +257,9 @@ class WindowRulesPage(BasePage):
         match_node = rule.get_child("match") if rule else None
 
         app_id_row = Adw.EntryRow(title="App ID (regex, e.g. ^kitty$)")
-        app_id_row.set_text(str(match_node.props.get("app-id", "")) if match_node else "")
+        app_id_row.set_text(
+            str(match_node.props.get("app-id", "")) if match_node else ""
+        )
         match_grp.add(app_id_row)
 
         title_row = Adw.EntryRow(title="Window Title (regex)")
@@ -257,7 +282,7 @@ class WindowRulesPage(BasePage):
         bool_rows: dict[str, Adw.SwitchRow] = {}
         for key, label in BOOL_ACTION_LABELS.items():
             sr = Adw.SwitchRow(title=label)
-            sr.set_active(rule.get_child(key) is not None if rule else False)
+            sr.set_active(_bool_action_active(rule, key))
             layout_grp.add(sr)
             bool_rows[key] = sr
 
@@ -272,7 +297,9 @@ class WindowRulesPage(BasePage):
             if op_node and op_node.args:
                 op_val = float(op_node.args[0])
         op_adj = Gtk.Adjustment(value=op_val, lower=0.0, upper=1.0, step_increment=0.05)
-        op_row = Adw.SpinRow(title="Opacity (0 = unset, 1 = fully opaque)", adjustment=op_adj, digits=2)
+        op_row = Adw.SpinRow(
+            title="Opacity (0 = unset, 1 = fully opaque)", adjustment=op_adj, digits=2
+        )
         fx_grp.add(op_row)
 
         blur_row = Adw.SwitchRow(
@@ -284,7 +311,9 @@ class WindowRulesPage(BasePage):
             be = rule.get_child("background-effect")
             if be is not None:
                 blur_child = be.get_child("blur")
-                has_blur = blur_child is not None and (not blur_child.args or blur_child.args[0] is True)
+                has_blur = blur_child is not None and (
+                    not blur_child.args or blur_child.args[0] is True
+                )
         blur_row.set_active(has_blur)
         fx_grp.add(blur_row)
 
@@ -300,7 +329,9 @@ class WindowRulesPage(BasePage):
             if rule:
                 cn = rule.get_child(key)
                 cur = cn.args[0] if cn and cn.args else 0
-            adj = Gtk.Adjustment(value=float(cur), lower=lo, upper=hi, step_increment=step)
+            adj = Gtk.Adjustment(
+                value=float(cur), lower=lo, upper=hi, step_increment=step
+            )
             sr = Adw.SpinRow(title=label, adjustment=adj, digits=digits)
             dim_grp.add(sr)
             num_rows[key] = sr
@@ -368,7 +399,7 @@ class WindowRulesPage(BasePage):
             # bool actions
             for key, sr in bool_rows.items():
                 if sr.get_active():
-                    new_rule.children.append(KdlNode(key, args=[True]))
+                    new_rule.children.append(_bool_action_node(key))
 
             # opacity
             op = op_row.get_value()
@@ -488,7 +519,9 @@ class WindowRulesPage(BasePage):
 
         toolbar_view = Adw.ToolbarView()
         hdr = Adw.HeaderBar()
-        hdr.set_title_widget(Adw.WindowTitle(title="Edit Layer Rule" if rule else "New Layer Rule"))
+        hdr.set_title_widget(
+            Adw.WindowTitle(title="Edit Layer Rule" if rule else "New Layer Rule")
+        )
         toolbar_view.add_top_bar(hdr)
 
         prefs = Adw.PreferencesPage()
@@ -496,7 +529,9 @@ class WindowRulesPage(BasePage):
         match_grp = Adw.PreferencesGroup(title="Match")
         match_node = rule.get_child("match") if rule else None
         ns_entry = Adw.EntryRow(title="Namespace (regex, e.g. ^waybar$)")
-        ns_entry.set_text(str(match_node.props.get("namespace", "")) if match_node else "")
+        ns_entry.set_text(
+            str(match_node.props.get("namespace", "")) if match_node else ""
+        )
         match_grp.add(ns_entry)
         prefs.add(match_grp)
 
@@ -504,7 +539,7 @@ class WindowRulesPage(BasePage):
         bool_rows: dict[str, Adw.SwitchRow] = {}
         for key, label in LAYER_BOOL_ACTION_LABELS.items():
             sr = Adw.SwitchRow(title=label)
-            sr.set_active(rule.get_child(key) is not None if rule else False)
+            sr.set_active(_bool_action_active(rule, key))
             act_grp.add(sr)
             bool_rows[key] = sr
 
@@ -558,7 +593,7 @@ class WindowRulesPage(BasePage):
                 new_rule.children.append(m)
             for key, sr in bool_rows.items():
                 if sr.get_active():
-                    new_rule.children.append(KdlNode(key, args=[True]))
+                    new_rule.children.append(_bool_action_node(key))
             if blur_row.get_active():
                 be = KdlNode("background-effect")
                 be.children.append(KdlNode("blur", args=[True]))

--- a/tests/test_kdl_parser.py
+++ b/tests/test_kdl_parser.py
@@ -42,7 +42,9 @@ class TestKdlRoundTrip(unittest.TestCase):
         self.assertAlmostEqual(scale.args[0], 2.0)
 
     def test_boolean_values(self):
-        nodes = parse_kdl("input {\n    keyboard {\n        repeat-rate 30\n        xkb-numlock true\n    }\n}\n")
+        nodes = parse_kdl(
+            "input {\n    keyboard {\n        repeat-rate 30\n        xkb-numlock true\n    }\n}\n"
+        )
         kb = nodes[0].get_child("keyboard")
         self.assertIsNotNone(kb)
         numlock = kb.get_child("xkb-numlock")
@@ -50,12 +52,20 @@ class TestKdlRoundTrip(unittest.TestCase):
         self.assertIs(numlock.args[0], True)
 
     def test_raw_string(self):
-        text = 'spawn-at-startup r#"bash -c \'echo hi\'"#\n'
+        text = "spawn-at-startup r#\"bash -c 'echo hi'\"#\n"
         nodes = parse_kdl(text)
         self.assertIsInstance(nodes[0].args[0], KdlRawString)
 
+    def test_raw_string_property_preserves_backslash(self):
+        src = 'match app-id="steam" title=r#"^notificationtoasts_\\d+_desktop$"#\n'
+        nodes = parse_kdl(src)
+        title = nodes[0].props["title"]
+        self.assertIsInstance(title, KdlRawString)
+        self.assertEqual(title, r"^notificationtoasts_\d+_desktop$")
+        self.assertIn(r'title=r"^notificationtoasts_\d+_desktop$"', write_kdl(nodes))
+
     def test_write_preserves_children(self):
-        src = 'layout {\n    gaps 16\n    border {\n        width 2\n    }\n}\n'
+        src = "layout {\n    gaps 16\n    border {\n        width 2\n    }\n}\n"
         nodes = self._roundtrip(src)
         layout = nodes[0]
         self.assertEqual(layout.name, "layout")

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -1,0 +1,39 @@
+"""Tests for window-rule editor serialization helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from nirimod.kdl_parser import KdlNode, write_kdl
+from nirimod.pages.window_rules import (
+    SCREENCAST_BLOCK_KEY,
+    _bool_action_active,
+    _bool_action_node,
+)
+
+
+class TestWindowRuleActions(unittest.TestCase):
+    def test_screencast_block_action_writes_valid_niri_syntax(self):
+        node = _bool_action_node(SCREENCAST_BLOCK_KEY)
+        out = write_kdl([KdlNode("window-rule", children=[node])])
+
+        self.assertIn('block-out-from "screencast"', out)
+        self.assertNotIn("block-out-from-screencast", out)
+
+    def test_screencast_block_action_reads_current_syntax(self):
+        rule = KdlNode(
+            "window-rule", children=[KdlNode("block-out-from", args=["screencast"])]
+        )
+
+        self.assertTrue(_bool_action_active(rule, SCREENCAST_BLOCK_KEY))
+
+    def test_screencast_block_action_reads_legacy_syntax(self):
+        rule = KdlNode(
+            "window-rule", children=[KdlNode("block-out-from-screencast", args=[True])]
+        )
+
+        self.assertTrue(_bool_action_active(rule, SCREENCAST_BLOCK_KEY))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes two window-rule save issues I hit while using NiriMod with niri 25.11.

First, raw regex properties like this were losing their backslashes after saving:

```kdl
title=r#"^notificationtoasts_\d+_desktop$"#
```

That became `notificationtoasts_d+_desktop`, which broke matching for Steam notification windows (As a suggestion, maybe the steam rule can be offered from the app too, as it is quite useful).

Second, the “Block from Screencast” option could save as `block-out-from-screencast true`, but current niri expects:

```kdl
block-out-from "screencast"
```

