### PR TITLE
Respect terminal preference in updater

### DIFF
--- a/nirimod/updater.py
+++ b/nirimod/updater.py
@@ -1,5 +1,7 @@
 import json
 import os
+import shlex
+import shutil
 import subprocess
 import tempfile
 import urllib.request
@@ -9,6 +11,17 @@ from gi.repository import GLib
 
 API_URL = "https://api.github.com/repos/srinivasr/nirimod/commits/main"
 INSTALL_DIR = os.path.expanduser("~/.local/share/nirimod")
+FALLBACK_TERMINALS = [
+    "xdg-terminal-exec",
+    "gnome-terminal",
+    "kgx",  # GNOME Console
+    "kitty",
+    "ghostty",
+    "alacritty",
+    "konsole",
+    "foot",
+    "xterm",
+]
 
 
 def check_for_updates(callback):
@@ -27,11 +40,15 @@ def check_for_updates(callback):
                 text=True,
             ).strip()
 
-            req = urllib.request.Request(API_URL, headers={"User-Agent": "NiriMod-Updater"})
+            req = urllib.request.Request(
+                API_URL, headers={"User-Agent": "NiriMod-Updater"}
+            )
             with urllib.request.urlopen(req, timeout=5) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
                 remote_hash = data.get("sha")
-                commit_msg = data.get("commit", {}).get("message", "New update available")
+                commit_msg = data.get("commit", {}).get(
+                    "message", "New update available"
+                )
 
             if remote_hash and remote_hash != local_hash:
                 GLib.idle_add(callback, remote_hash, commit_msg)
@@ -43,6 +60,31 @@ def check_for_updates(callback):
             GLib.idle_add(callback, None, None)
 
     threading.Thread(target=_do_check, daemon=True).start()
+
+
+def _terminal_candidates():
+    terminal = os.environ.get("TERMINAL", "").strip()
+    if terminal:
+        yield terminal
+    yield from FALLBACK_TERMINALS
+
+
+def _build_terminal_command(terminal: str, script_path: str) -> list[str] | None:
+    try:
+        parts = shlex.split(terminal)
+    except ValueError:
+        return None
+
+    if not parts:
+        return None
+
+    if os.path.basename(parts[0]) == "xdg-terminal-exec":
+        return [*parts, script_path]
+
+    if parts[-1] in {"-e", "--execute", "-x"}:
+        return [*parts, script_path]
+
+    return [*parts, "-e", script_path]
 
 
 def launch_updater_in_terminal():
@@ -59,26 +101,15 @@ read
         f.write(script_content)
     os.chmod(script_path, stat.S_IRWXU)
 
-    terminals = [
-        "xdg-terminal-exec",
-        "gnome-terminal",
-        "kgx",       # GNOME Console
-        "kitty",
-        "alacritty",
-        "konsole",
-        "foot",
-        "xterm",
-    ]
+    for term in _terminal_candidates():
+        command = _build_terminal_command(term, script_path)
+        if command is None or shutil.which(command[0]) is None:
+            continue
 
-    for term in terminals:
-        if subprocess.call(["which", term], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0:
-            try:
-                if term == "xdg-terminal-exec":
-                    subprocess.Popen([term, script_path])
-                else:
-                    subprocess.Popen([term, "-e", script_path])
-                return
-            except Exception:
-                continue
+        try:
+            subprocess.Popen(command)
+            return
+        except Exception:
+            continue
 
     print("Could not find a suitable terminal to launch the update.")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,68 @@
+"""Unit tests for updater terminal selection."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from nirimod import updater
+
+
+class TestTerminalCandidates(unittest.TestCase):
+    def test_terminal_env_is_preferred(self):
+        with patch.dict(os.environ, {"TERMINAL": "ghostty"}, clear=False):
+            candidates = list(updater._terminal_candidates())
+
+        self.assertEqual(candidates[0], "ghostty")
+        self.assertIn("xdg-terminal-exec", candidates)
+
+    def test_ghostty_is_a_fallback_terminal(self):
+        self.assertIn("ghostty", updater.FALLBACK_TERMINALS)
+
+
+class TestBuildTerminalCommand(unittest.TestCase):
+    def test_xdg_terminal_exec_gets_script_directly(self):
+        command = updater._build_terminal_command("xdg-terminal-exec", "/tmp/update.sh")
+
+        self.assertEqual(command, ["xdg-terminal-exec", "/tmp/update.sh"])
+
+    def test_regular_terminal_uses_execute_flag(self):
+        command = updater._build_terminal_command("ghostty", "/tmp/update.sh")
+
+        self.assertEqual(command, ["ghostty", "-e", "/tmp/update.sh"])
+
+    def test_terminal_command_with_existing_execute_flag(self):
+        command = updater._build_terminal_command(
+            "ghostty --gtk-single-instance=false -e", "/tmp/update.sh"
+        )
+
+        self.assertEqual(
+            command, ["ghostty", "--gtk-single-instance=false", "-e", "/tmp/update.sh"]
+        )
+
+    def test_invalid_terminal_command_is_ignored(self):
+        command = updater._build_terminal_command("ghostty '", "/tmp/update.sh")
+
+        self.assertIsNone(command)
+
+
+class TestLaunchUpdaterInTerminal(unittest.TestCase):
+    def test_launch_uses_terminal_env(self):
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.dict(os.environ, {"TERMINAL": "ghostty"}, clear=False),
+            patch.object(updater.tempfile, "gettempdir", return_value=temp_dir),
+            patch.object(updater.shutil, "which", return_value="/usr/bin/ghostty"),
+            patch.object(updater.subprocess, "Popen") as popen,
+        ):
+            updater.launch_updater_in_terminal()
+
+        popen.assert_called_once_with(
+            ["ghostty", "-e", os.path.join(temp_dir, "nirimod_update.sh")]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Make the updater terminal launcher respect the user’s configured terminal before falling back to known terminal emulators, which also lacked Ghostty.

The updater now:
- tries `$TERMINAL` first
- keeps `xdg-terminal-exec` support
- adds Ghostty to the fallback terminals
- avoids duplicating `-e` when the terminal command already includes an execute flag

Note 1: `uv run --with mypy mypy nirimod` still fails on existing baseline GI/stub and typing issues, unrelated to this change. The updater-specific failure is the pre-existing `nirimod/updater.py:10: error: Skipping analyzing "gi.repository": module is installed, but missing library stubs or py.typed marker`.

Note 2: Yes, I only have Ghostty installed :) The updater previously opened Konsole because it was present in the fallback list, which I thought was a configuration error on my side, so I just removed Konsole, retried and could not update. Which exposed that Ghostty was missing from the fallback list and that `$TERMINAL` was not respected upon digging in.
