### PR TITLE
added NIRIMOD_CONFIG_DIR environment variable for configurable config

### DIFF
--- a/nirimod/kdl_parser.py
+++ b/nirimod/kdl_parser.py
@@ -13,9 +13,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-NIRI_CONFIG = Path.home() / ".config" / "niri" / "config.kdl"
-PROFILES_DIR = Path.home() / ".config" / "niri" / "profiles"
-BACKUP_DIR = Path.home() / ".config" / "niri" / "backup"
+_config_dir = Path(
+    os.environ.get("NIRIMOD_CONFIG_DIR", Path.home() / ".config" / "niri")
+)
+NIRI_CONFIG  = _config_dir / "config.kdl"
+PROFILES_DIR = _config_dir / "profiles"
+BACKUP_DIR   = _config_dir / "backup"
 
 
 class KdlRawString(str):

--- a/nirimod/window.py
+++ b/nirimod/window.py
@@ -645,7 +645,7 @@ class NiriModWindow(Adw.ApplicationWindow):
         elif "error" in message.lower() or "failed" in message.lower():
             toast.set_button_label("Copy")
             toast.connect("button-clicked", lambda *_: self.get_clipboard().set(message))
-            
+
         self._toast_overlay.add_toast(toast)
 
     def _check_onboarding(self):
@@ -657,7 +657,7 @@ class NiriModWindow(Adw.ApplicationWindow):
         filenames = "\n".join(f"  • <tt>{p.name}</tt>" for p in source_files)
         body = (
             f"NiriMod will back up your config files to\n"
-            f"<tt>~/.config/niri/backup/</tt>:\n\n"
+            f"<tt>{BACKUP_DIR}</tt>:\n\n"
             f"{filenames}\n"
         )
 
@@ -713,7 +713,7 @@ class NiriModWindow(Adw.ApplicationWindow):
                     except ValueError:
                         # Fallback if the source file is not under NIRI_CONFIG.parent
                         shutil.copy2(p, BACKUP_DIR / p.name)
-            self.show_toast("Backup created in ~/.config/niri/backup/ ✓")
+            self.show_toast(f"Backup created in {BACKUP_DIR} ✓")
         except Exception as e:
             self.show_toast(f"Backup failed: {e}", timeout=6)
 
@@ -743,7 +743,7 @@ class NiriModWindow(Adw.ApplicationWindow):
                         shutil.copy2(f, target)
                     elif f.is_dir():
                         _restore(f, dest_dir)
-                        
+
             _restore(BACKUP_DIR, NIRI_CONFIG.parent)
             shutil.rmtree(BACKUP_DIR)
             self.app_state.reload_from_disk()


### PR DESCRIPTION
Config paths now read from NIRIMOD_CONFIG_DIR instead of being hardcoded. They fall back to the original default if unset.

I needed this because I use NixOS and manage my niri config in another location. To use this I wrapped the binary using makeWrapper to point NiriMod at the right place:
```nix
pkgs.symlinkJoin {
  name  = "nirimod";
  paths = [ inputs.nirimod.packages.${pkgs.stdenv.hostPlatform.system}.default ];
  buildInputs = [ pkgs.makeWrapper ];
  postBuild = ''
    wrapProgram $out/bin/nirimod \
      --run 'export NIRIMOD_CONFIG_DIR="$HOME/nixconf/modules/apps/niri"'
  '';
}
```
https://github.com/user-attachments/assets/1f0a08ff-80cc-4199-8eb2-72c05c88994e