### PR TITLE
Add global window blur controls

### DIFF
--- a/nirimod/pages/appearance.py
+++ b/nirimod/pages/appearance.py
@@ -11,6 +11,20 @@ from gi.repository import Adw, Gdk, Gtk
 
 from nirimod.kdl_parser import KdlNode, find_or_create, set_child_arg, set_node_flag
 from nirimod.pages.base import BasePage
+from nirimod.window_effects import (
+    focused_window_blur_enabled,
+    get_global_draw_border_with_background,
+    get_global_corner_radius,
+    get_global_window_opacity,
+    global_window_blur_enabled,
+    global_window_xray_enabled,
+    set_focused_window_blur,
+    set_global_draw_border_with_background,
+    set_global_corner_radius,
+    set_global_window_blur,
+    set_global_window_opacity,
+    set_global_window_xray,
+)
 
 
 def _parse_color(color_str: str) -> Gdk.RGBA:
@@ -115,13 +129,83 @@ class AppearancePage(BasePage):
 
         blur_grp = Adw.PreferencesGroup(
             title="Blur (Global)",
-            description="Requires Niri 26.04 or later. Sets the global blur quality parameters.",
+            description=(
+                "Requires Niri 26.04 or later. Sets blur quality and optional "
+                "window blur rules."
+            ),
         )
         blur_node = next((n for n in nodes if n.name == "blur"), None)
 
+        blur_enabled_row = Adw.SwitchRow(
+            title="Enable Window Blur",
+            subtitle="Adds background-effect { blur true } to the global window rule",
+        )
+        blur_enabled_row.set_active(global_window_blur_enabled(nodes))
+        blur_enabled_row.connect(
+            "notify::active",
+            lambda r, _: self._set_window_blur_enabled(r.get_active()),
+        )
+        blur_grp.add(blur_enabled_row)
+
+        focused_blur_row = Adw.SwitchRow(
+            title="Keep Focused Windows Blurred",
+            subtitle="Adds a focused-window rule that forces blur on",
+        )
+        focused_blur_row.set_active(focused_window_blur_enabled(nodes))
+        focused_blur_row.connect(
+            "notify::active",
+            lambda r, _: self._set_focused_window_blur_enabled(r.get_active()),
+        )
+        blur_grp.add(focused_blur_row)
+
+        xray_row = Adw.SwitchRow(
+            title="Use Xray Wallpaper Blur",
+            subtitle="Use wallpaper-only blur; disable for regular background blur",
+        )
+        xray_row.set_active(global_window_xray_enabled(nodes))
+        xray_row.connect(
+            "notify::active",
+            lambda r, _: self._set_window_blur_xray(r.get_active()),
+        )
+        blur_grp.add(xray_row)
+
+        opacity_val = get_global_window_opacity(nodes)
+        opacity_adj = Gtk.Adjustment(
+            value=opacity_val, lower=0.1, upper=1.0, step_increment=0.05
+        )
+        opacity_row = Adw.SpinRow(
+            title="Window Opacity (1 = unset)", adjustment=opacity_adj, digits=2
+        )
+
+        opacity_row._last_val = opacity_val
+
+        def _on_opacity_changed(r, _):
+            new_val = round(float(r.get_value()), 2)
+            if new_val != getattr(r, "_last_val", None):
+                r._last_val = new_val
+                self._set_window_opacity(new_val)
+
+        opacity_row.connect("notify::value", _on_opacity_changed)
+        blur_grp.add(opacity_row)
+
+        border_bg_row = Adw.SwitchRow(
+            title="Draw Border With Background",
+            subtitle="Disable to avoid focus colors behind translucent windows",
+        )
+        border_bg_row.set_active(get_global_draw_border_with_background(nodes))
+        border_bg_row.connect(
+            "notify::active",
+            lambda r, _: self._set_draw_border_with_background(r.get_active()),
+        )
+        blur_grp.add(border_bg_row)
+
         passes_val = int(blur_node.child_arg("passes") if blur_node else 0)
-        passes_adj = Gtk.Adjustment(value=passes_val, lower=0, upper=10, step_increment=1)
-        passes_row = Adw.SpinRow(title="Passes (0 = disabled)", adjustment=passes_adj, digits=0)
+        passes_adj = Gtk.Adjustment(
+            value=passes_val, lower=0, upper=10, step_increment=1
+        )
+        passes_row = Adw.SpinRow(
+            title="Passes (0 = disabled)", adjustment=passes_adj, digits=0
+        )
 
         passes_row._last_val = passes_val
 
@@ -135,7 +219,9 @@ class AppearancePage(BasePage):
         blur_grp.add(passes_row)
 
         offset_val = float(blur_node.child_arg("offset") if blur_node else 2.0)
-        offset_adj = Gtk.Adjustment(value=offset_val, lower=0.0, upper=20.0, step_increment=0.1)
+        offset_adj = Gtk.Adjustment(
+            value=offset_val, lower=0.0, upper=20.0, step_increment=0.1
+        )
         offset_row = Adw.SpinRow(title="Offset", adjustment=offset_adj, digits=1)
 
         offset_row._last_val = offset_val
@@ -150,7 +236,9 @@ class AppearancePage(BasePage):
         blur_grp.add(offset_row)
 
         noise_val = float(blur_node.child_arg("noise") if blur_node else 0.0)
-        noise_adj = Gtk.Adjustment(value=noise_val, lower=0.0, upper=1.0, step_increment=0.01)
+        noise_adj = Gtk.Adjustment(
+            value=noise_val, lower=0.0, upper=1.0, step_increment=0.01
+        )
         noise_row = Adw.SpinRow(title="Noise", adjustment=noise_adj, digits=2)
 
         noise_row._last_val = noise_val
@@ -165,8 +253,12 @@ class AppearancePage(BasePage):
         blur_grp.add(noise_row)
 
         saturation_val = float(blur_node.child_arg("saturation") if blur_node else 1.0)
-        saturation_adj = Gtk.Adjustment(value=saturation_val, lower=0.0, upper=5.0, step_increment=0.1)
-        saturation_row = Adw.SpinRow(title="Saturation", adjustment=saturation_adj, digits=1)
+        saturation_adj = Gtk.Adjustment(
+            value=saturation_val, lower=0.0, upper=5.0, step_increment=0.1
+        )
+        saturation_row = Adw.SpinRow(
+            title="Saturation", adjustment=saturation_adj, digits=1
+        )
 
         saturation_row._last_val = saturation_val
 
@@ -183,19 +275,10 @@ class AppearancePage(BasePage):
 
         misc_grp = Adw.PreferencesGroup(title="Window Geometry")
 
-        # geometry-corner-radius is a window-rule-level setting but also applied globally
-        # get current cr if it exists
-        wr_nodes = [
-            n
-            for n in nodes
-            if n.name == "window-rule"
-            and not n.get_children("match")
-            and n.get_child("geometry-corner-radius")
-        ]
-        cr_val = int(wr_nodes[0].child_arg("geometry-corner-radius") if wr_nodes else 0)
+        cr_val = get_global_corner_radius(nodes)
         cr_adj = Gtk.Adjustment(value=cr_val, lower=0, upper=40, step_increment=1)
         cr_row = Adw.SpinRow(
-            title="Corner Radius (px, applied via window-rule)",
+            title="Corner Radius (px)",
             adjustment=cr_adj,
             digits=0,
         )
@@ -331,28 +414,28 @@ class AppearancePage(BasePage):
         set_child_arg(blur_node, prop, value)
         self._commit(f"blur {prop}")
 
-    def _set_corner_radius(self, radius: int):
-        # Apply via global window-rule
-        nodes = self._nodes
+    def _set_window_blur_enabled(self, enabled: bool):
+        set_global_window_blur(self._nodes, enabled)
+        self._commit("window blur")
 
-        wr = next(
-            (
-                n
-                for n in nodes
-                if n.name == "window-rule"
-                and n.get_child("geometry-corner-radius")
-                and not n.get_children("match")
-            ),
-            None,
-        )
-        if radius > 0:
-            if wr is None:
-                wr = KdlNode("window-rule")
-                nodes.append(wr)
-            set_child_arg(wr, "geometry-corner-radius", radius)
-            set_child_arg(wr, "clip-to-geometry", True)
-        elif wr is not None:
-            nodes.remove(wr)
+    def _set_focused_window_blur_enabled(self, enabled: bool):
+        set_focused_window_blur(self._nodes, enabled)
+        self._commit("focused window blur")
+
+    def _set_window_blur_xray(self, enabled: bool):
+        set_global_window_xray(self._nodes, enabled)
+        self._commit("window blur xray")
+
+    def _set_window_opacity(self, opacity: float):
+        set_global_window_opacity(self._nodes, opacity)
+        self._commit("window opacity")
+
+    def _set_draw_border_with_background(self, enabled: bool):
+        set_global_draw_border_with_background(self._nodes, enabled)
+        self._commit("draw border with background")
+
+    def _set_corner_radius(self, radius: int):
+        set_global_corner_radius(self._nodes, radius)
         self._commit("corner radius")
 
     def refresh(self):

--- a/nirimod/window_effects.py
+++ b/nirimod/window_effects.py
@@ -1,0 +1,257 @@
+"""Helpers for Niri global window effect rules."""
+
+from __future__ import annotations
+
+from nirimod.kdl_parser import KdlNode, remove_child, set_child_arg
+
+_RULE_CHILD_ORDER = [
+    "match",
+    "exclude",
+    "geometry-corner-radius",
+    "clip-to-geometry",
+    "draw-border-with-background",
+    "opacity",
+    "background-effect",
+]
+
+_EFFECT_CHILD_ORDER = ["blur", "xray"]
+
+
+def _is_global_window_rule(node: KdlNode) -> bool:
+    return (
+        node.name == "window-rule"
+        and not node.get_children("match")
+        and not node.get_children("exclude")
+    )
+
+
+def _is_focused_window_rule(node: KdlNode) -> bool:
+    if node.name != "window-rule" or node.get_children("exclude"):
+        return False
+    matches = node.get_children("match")
+    if len(matches) != 1:
+        return False
+    match = matches[0]
+    return match.args == [] and match.props == {"is-focused": True}
+
+
+def _global_window_rule(nodes: list[KdlNode]) -> KdlNode | None:
+    return next((n for n in reversed(nodes) if _is_global_window_rule(n)), None)
+
+
+def _focused_window_rule(nodes: list[KdlNode]) -> KdlNode | None:
+    return next((n for n in reversed(nodes) if _is_focused_window_rule(n)), None)
+
+
+def _ensure_global_window_rule(nodes: list[KdlNode]) -> KdlNode:
+    rule = _global_window_rule(nodes)
+    if rule is None:
+        rule = KdlNode("window-rule")
+        rule.leading_trivia = "\n"
+        nodes.append(rule)
+    return rule
+
+
+def _ensure_focused_window_rule(nodes: list[KdlNode]) -> KdlNode:
+    rule = _focused_window_rule(nodes)
+    if rule is None:
+        rule = KdlNode("window-rule")
+        rule.leading_trivia = "\n"
+        rule.children.append(KdlNode("match", props={"is-focused": True}))
+        nodes.append(rule)
+    return rule
+
+
+def _background_effect(rule: KdlNode) -> KdlNode | None:
+    return rule.get_child("background-effect")
+
+
+def _ensure_background_effect(rule: KdlNode) -> KdlNode:
+    effect = _background_effect(rule)
+    if effect is None:
+        effect = KdlNode("background-effect")
+        effect.leading_trivia = "\n"
+        rule.children.append(effect)
+    return effect
+
+
+def _remove_rule_if_empty(nodes: list[KdlNode], rule: KdlNode) -> None:
+    if not rule.args and not rule.props and not rule.children and rule in nodes:
+        nodes.remove(rule)
+
+
+def _remove_background_effect_if_empty(rule: KdlNode) -> None:
+    effect = _background_effect(rule)
+    if effect and not effect.args and not effect.props and not effect.children:
+        remove_child(rule, "background-effect")
+
+
+def _compact_generated_spacing(node: KdlNode) -> None:
+    if not node.trailing_trivia or node.trailing_trivia.isspace():
+        node.trailing_trivia = "\n"
+    for child in node.children:
+        if not child.leading_trivia or child.leading_trivia.isspace():
+            child.leading_trivia = ""
+        if not child.trailing_trivia or child.trailing_trivia.isspace():
+            child.trailing_trivia = ""
+        if child.name == "background-effect":
+            _compact_generated_spacing(child)
+
+
+def _sort_children_by_name(node: KdlNode, order: list[str]) -> None:
+    order_index = {name: index for index, name in enumerate(order)}
+    indexed_children = list(enumerate(node.children))
+    indexed_children.sort(
+        key=lambda item: (order_index.get(item[1].name, len(order)), item[0])
+    )
+    node.children = [child for _, child in indexed_children]
+
+
+def _finalize_window_rule(rule: KdlNode) -> None:
+    effect = _background_effect(rule)
+    if effect is not None:
+        _sort_children_by_name(effect, _EFFECT_CHILD_ORDER)
+    _sort_children_by_name(rule, _RULE_CHILD_ORDER)
+    _compact_generated_spacing(rule)
+
+
+def _rule_opacity(rule: KdlNode | None) -> float:
+    if rule is None:
+        return 1.0
+    value = rule.child_arg("opacity", 1.0)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def get_global_draw_border_with_background(nodes: list[KdlNode]) -> bool:
+    rule = _global_window_rule(nodes)
+    if rule is None:
+        return True
+    return rule.child_arg("draw-border-with-background", True) is not False
+
+
+def set_global_draw_border_with_background(nodes: list[KdlNode], enabled: bool) -> None:
+    rule = _ensure_global_window_rule(nodes)
+    if enabled:
+        remove_child(rule, "draw-border-with-background")
+    else:
+        set_child_arg(rule, "draw-border-with-background", False)
+    _finalize_window_rule(rule)
+    _remove_rule_if_empty(nodes, rule)
+
+
+def global_window_blur_enabled(nodes: list[KdlNode]) -> bool:
+    rule = _global_window_rule(nodes)
+    return _rule_blur_enabled(rule)
+
+
+def focused_window_blur_enabled(nodes: list[KdlNode]) -> bool:
+    rule = _focused_window_rule(nodes)
+    return _rule_blur_enabled(rule)
+
+
+def _rule_blur_enabled(rule: KdlNode | None) -> bool:
+    if rule is None:
+        return False
+    effect = _background_effect(rule)
+    if effect is None:
+        return False
+    blur = effect.get_child("blur")
+    return blur is not None and (not blur.args or blur.args[0] is True)
+
+
+def set_global_window_blur(nodes: list[KdlNode], enabled: bool) -> None:
+    if enabled:
+        rule = _ensure_global_window_rule(nodes)
+        effect = _ensure_background_effect(rule)
+        set_child_arg(effect, "blur", True)
+        _finalize_window_rule(rule)
+        return
+
+    existing_rule = _global_window_rule(nodes)
+    if existing_rule is None:
+        return
+    existing_effect = _background_effect(existing_rule)
+    if existing_effect is not None:
+        remove_child(existing_effect, "blur")
+        _remove_background_effect_if_empty(existing_rule)
+    _finalize_window_rule(existing_rule)
+    _remove_rule_if_empty(nodes, existing_rule)
+
+
+def set_focused_window_blur(nodes: list[KdlNode], enabled: bool) -> None:
+    if enabled:
+        rule = _ensure_focused_window_rule(nodes)
+
+        effect = _ensure_background_effect(rule)
+        set_child_arg(effect, "blur", True)
+        _finalize_window_rule(rule)
+        return
+
+    existing_rule = _focused_window_rule(nodes)
+    if existing_rule is None:
+        return
+    existing_effect = _background_effect(existing_rule)
+    if existing_effect is not None:
+        remove_child(existing_effect, "blur")
+        _remove_background_effect_if_empty(existing_rule)
+    _finalize_window_rule(existing_rule)
+    if len(existing_rule.children) == 1 and existing_rule.get_child("match"):
+        nodes.remove(existing_rule)
+
+
+def global_window_xray_enabled(nodes: list[KdlNode]) -> bool:
+    rule = _global_window_rule(nodes)
+    if rule is None:
+        return True
+    effect = _background_effect(rule)
+    if effect is None:
+        return True
+    xray = effect.get_child("xray")
+    return xray is None or not xray.args or xray.args[0] is True
+
+
+def set_global_window_xray(nodes: list[KdlNode], enabled: bool) -> None:
+    rule = _ensure_global_window_rule(nodes)
+    effect = _ensure_background_effect(rule)
+    set_child_arg(effect, "xray", enabled)
+    _finalize_window_rule(rule)
+
+
+def get_global_window_opacity(nodes: list[KdlNode]) -> float:
+    return _rule_opacity(_global_window_rule(nodes))
+
+
+def set_global_window_opacity(nodes: list[KdlNode], opacity: float) -> None:
+    rule = _ensure_global_window_rule(nodes)
+    if opacity < 1.0:
+        set_child_arg(rule, "opacity", round(opacity, 2))
+    else:
+        remove_child(rule, "opacity")
+    _finalize_window_rule(rule)
+    _remove_rule_if_empty(nodes, rule)
+
+
+def get_global_corner_radius(nodes: list[KdlNode]) -> int:
+    rule = _global_window_rule(nodes)
+    if rule is None:
+        return 0
+    value = rule.child_arg("geometry-corner-radius", 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def set_global_corner_radius(nodes: list[KdlNode], radius: int) -> None:
+    rule = _ensure_global_window_rule(nodes)
+    if radius > 0:
+        set_child_arg(rule, "geometry-corner-radius", radius)
+        set_child_arg(rule, "clip-to-geometry", True)
+    else:
+        remove_child(rule, "geometry-corner-radius")
+        remove_child(rule, "clip-to-geometry")
+    _finalize_window_rule(rule)
+    _remove_rule_if_empty(nodes, rule)

--- a/tests/test_window_effects.py
+++ b/tests/test_window_effects.py
@@ -1,0 +1,207 @@
+"""Tests for global window effect rule helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from nirimod.kdl_parser import KdlNode, parse_kdl, write_kdl
+from nirimod.window_effects import (
+    focused_window_blur_enabled,
+    get_global_draw_border_with_background,
+    get_global_corner_radius,
+    get_global_window_opacity,
+    global_window_blur_enabled,
+    global_window_xray_enabled,
+    set_focused_window_blur,
+    set_global_draw_border_with_background,
+    set_global_corner_radius,
+    set_global_window_blur,
+    set_global_window_opacity,
+    set_global_window_xray,
+)
+
+
+class TestGlobalWindowEffects(unittest.TestCase):
+    def test_enabling_blur_creates_matchless_window_rule(self):
+        nodes: list[KdlNode] = []
+
+        set_global_window_blur(nodes, True)
+
+        out = write_kdl(nodes)
+        self.assertIn("window-rule", out)
+        self.assertIn("background-effect", out)
+        self.assertIn("blur true", out)
+        self.assertNotIn("draw-border-with-background", out)
+        self.assertTrue(global_window_blur_enabled(nodes))
+
+    def test_disabling_blur_preserves_other_window_effect_settings(self):
+        nodes = parse_kdl(
+            """
+window-rule {
+    geometry-corner-radius 16
+    draw-border-with-background false
+    background-effect {
+        blur true
+        xray false
+    }
+}
+"""
+        )
+
+        set_global_window_blur(nodes, False)
+
+        rule = nodes[0]
+        self.assertEqual(rule.child_arg("geometry-corner-radius"), 16)
+        self.assertIsNotNone(rule.get_child("draw-border-with-background"))
+        self.assertIsNotNone(rule.get_child("background-effect"))
+        self.assertIsNone(rule.get_child("background-effect").get_child("blur"))
+        self.assertIsNotNone(rule.get_child("background-effect").get_child("xray"))
+        self.assertFalse(global_window_blur_enabled(nodes))
+
+    def test_corner_radius_writes_clip_and_can_be_removed(self):
+        nodes: list[KdlNode] = []
+
+        set_global_corner_radius(nodes, 16)
+
+        self.assertEqual(get_global_corner_radius(nodes), 16)
+        out = write_kdl(nodes)
+        self.assertIn("geometry-corner-radius 16", out)
+        self.assertIn("clip-to-geometry true", out)
+
+        set_global_corner_radius(nodes, 0)
+
+        self.assertEqual(nodes, [])
+
+    def test_matched_rules_are_not_reused_as_global_effect_rules(self):
+        nodes = parse_kdl(
+            """
+window-rule {
+    match app-id="Alacritty"
+    background-effect {
+        blur true
+    }
+}
+"""
+        )
+
+        set_global_corner_radius(nodes, 12)
+
+        self.assertEqual(len([n for n in nodes if n.name == "window-rule"]), 2)
+        self.assertIsNone(nodes[0].get_child("geometry-corner-radius"))
+        self.assertEqual(get_global_corner_radius(nodes), 12)
+
+    def test_global_opacity_is_removed_when_opaque(self):
+        nodes: list[KdlNode] = []
+
+        set_global_window_opacity(nodes, 0.9)
+
+        self.assertEqual(get_global_window_opacity(nodes), 0.9)
+        self.assertIn("opacity 0.9", write_kdl(nodes))
+
+        set_global_window_opacity(nodes, 1.0)
+
+        self.assertEqual(nodes, [])
+
+    def test_draw_border_with_background_can_be_toggled(self):
+        nodes: list[KdlNode] = []
+
+        self.assertTrue(get_global_draw_border_with_background(nodes))
+
+        set_global_draw_border_with_background(nodes, False)
+
+        self.assertFalse(get_global_draw_border_with_background(nodes))
+        self.assertIn("draw-border-with-background false", write_kdl(nodes))
+
+        set_global_draw_border_with_background(nodes, True)
+
+        self.assertTrue(get_global_draw_border_with_background(nodes))
+        self.assertEqual(nodes, [])
+
+    def test_xray_false_is_written_with_blur(self):
+        nodes: list[KdlNode] = []
+
+        set_global_window_blur(nodes, True)
+        set_global_window_xray(nodes, False)
+
+        out = write_kdl(nodes)
+        self.assertIn("blur true", out)
+        self.assertIn("xray false", out)
+        self.assertFalse(global_window_xray_enabled(nodes))
+
+    def test_xray_toggle_does_not_enable_blur(self):
+        nodes: list[KdlNode] = []
+
+        set_global_window_xray(nodes, True)
+
+        out = write_kdl(nodes)
+        self.assertIn("xray true", out)
+        self.assertNotIn("blur true", out)
+        self.assertFalse(global_window_blur_enabled(nodes))
+
+    def test_generated_global_window_effect_rule_is_compact(self):
+        nodes: list[KdlNode] = []
+
+        set_global_corner_radius(nodes, 16)
+        set_global_draw_border_with_background(nodes, False)
+        set_global_window_blur(nodes, True)
+        set_global_window_xray(nodes, False)
+        set_global_window_opacity(nodes, 0.75)
+
+        self.assertEqual(
+            write_kdl(nodes).strip(),
+            """window-rule {
+    geometry-corner-radius 16
+    clip-to-geometry true
+    draw-border-with-background false
+    opacity 0.75
+    background-effect {
+        blur true
+        xray false
+    }
+}""",
+        )
+
+    def test_focused_blur_rule_does_not_duplicate_global_effect_settings(self):
+        nodes: list[KdlNode] = []
+        set_global_window_blur(nodes, True)
+        set_global_window_xray(nodes, False)
+        set_global_window_opacity(nodes, 0.75)
+
+        set_focused_window_blur(nodes, True)
+
+        out = write_kdl(nodes)
+        self.assertIn("match is-focused=true", out)
+        self.assertEqual(out.count("opacity 0.75"), 1)
+        self.assertEqual(out.count("blur true"), 2)
+        self.assertEqual(out.count("xray false"), 1)
+        self.assertTrue(focused_window_blur_enabled(nodes))
+
+    def test_disabling_focused_blur_preserves_other_focused_rule_settings(self):
+        nodes = parse_kdl(
+            """
+window-rule {
+    match is-focused=true
+    block-out-from "screen-capture"
+    draw-border-with-background false
+    opacity 0.75
+    background-effect {
+        blur true
+        xray false
+    }
+}
+"""
+        )
+
+        set_focused_window_blur(nodes, False)
+
+        out = write_kdl(nodes)
+        self.assertIn('block-out-from "screen-capture"', out)
+        self.assertIn("draw-border-with-background false", out)
+        self.assertIn("opacity 0.75", out)
+        self.assertNotIn("blur true", out)
+        self.assertIn("xray false", out)
+        self.assertFalse(focused_window_blur_enabled(nodes))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds global window blur controls under appearence.

- add helper logic for matchless and focused `window-rule` effects
- keep blur, xray, opacity, focused blur, and border background as separate config writes
- preserve unrelated rule settings when toggling individual options

Note: full `uv run pytest -q` still imports `test_features.py`, which calls `sys.exit(0)` during collection; running `uv run python test_features.py` directly passes.
