### PR TITLE
Matching license in pyproject.toml with LICENSE file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nirimod"
 version = "0.1.0"
 description = "A polished GTK4/libadwaita GUI configurator for the niri Wayland compositor"
 readme = "README.md"
-license = { text = "GPL-3.0-or-later" }
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     # PyGObject (gi.repository.Gtk, Adw) must be installed via system package manager:


### PR DESCRIPTION
Hello,

I have noticed that there was a discrepancy between the license defined in the pyproject.toml and the actual LICENSE file. 

Since the LICENSE file is usually the source of truth, I suggest this change. 