### PR TITLE
Add window rule floating position controls

### DIFF
--- a/nirimod/pages/window_rules.py
+++ b/nirimod/pages/window_rules.py
@@ -54,6 +54,18 @@ LAYER_BOOL_ACTION_LABELS = {
     SCREENCAST_BLOCK_KEY: "Block from Screencast",
 }
 
+FLOATING_POSITION_RELATIVE_TO_OPTIONS = [
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right",
+    "top",
+    "bottom",
+    "left",
+    "right",
+]
+DEFAULT_FLOATING_POSITION_RELATIVE_TO = "top-left"
+
 
 def _bool_action_active(rule: KdlNode | None, key: str) -> bool:
     if rule is None:
@@ -73,6 +85,37 @@ def _bool_action_node(key: str) -> KdlNode:
     if key == SCREENCAST_BLOCK_KEY:
         return KdlNode(SCREENCAST_BLOCK_KEY, args=["screencast"])
     return KdlNode(key, args=[True])
+
+
+def _floating_position_setting(rule: KdlNode | None) -> tuple[bool, int, int, str]:
+    if rule is None:
+        return (False, 0, 0, DEFAULT_FLOATING_POSITION_RELATIVE_TO)
+
+    node = rule.get_child("default-floating-position")
+    if node is None:
+        return (False, 0, 0, DEFAULT_FLOATING_POSITION_RELATIVE_TO)
+
+    x = int(node.props.get("x", 0))
+    y = int(node.props.get("y", 0))
+    relative_to = str(
+        node.props.get("relative-to", DEFAULT_FLOATING_POSITION_RELATIVE_TO)
+    )
+    if relative_to not in FLOATING_POSITION_RELATIVE_TO_OPTIONS:
+        relative_to = DEFAULT_FLOATING_POSITION_RELATIVE_TO
+    return (True, x, y, relative_to)
+
+
+def _make_floating_position_node(
+    enabled: bool, x: int, y: int, relative_to: str
+) -> KdlNode | None:
+    if not enabled:
+        return None
+    if relative_to not in FLOATING_POSITION_RELATIVE_TO_OPTIONS:
+        relative_to = DEFAULT_FLOATING_POSITION_RELATIVE_TO
+    return KdlNode(
+        "default-floating-position",
+        props={"x": int(x), "y": int(y), "relative-to": relative_to},
+    )
 
 
 def _rule_summary(rule: KdlNode) -> tuple[str, str]:
@@ -232,6 +275,86 @@ class WindowRulesPage(BasePage):
         t.connect("button-clicked", lambda *_: self._win._do_undo())
         self._win._toast_overlay.add_toast(t)
 
+    def _add_floating_position_controls(
+        self, group: Adw.PreferencesGroup, rule: KdlNode | None
+    ) -> dict[str, Gtk.Widget]:
+        enabled, x, y, relative_to = _floating_position_setting(rule)
+
+        enabled_row = Adw.SwitchRow(
+            title="Default Floating Position",
+            subtitle="Set the initial position for matching floating windows",
+        )
+        enabled_row.set_active(enabled)
+        group.add(enabled_row)
+
+        relative_model = Gtk.StringList.new(FLOATING_POSITION_RELATIVE_TO_OPTIONS)
+        relative_row = Adw.ComboRow(title="Relative To", model=relative_model)
+        relative_row.set_selected(
+            FLOATING_POSITION_RELATIVE_TO_OPTIONS.index(relative_to)
+        )
+        group.add(relative_row)
+
+        x_adj = Gtk.Adjustment(
+            value=x,
+            lower=-7680,
+            upper=7680,
+            step_increment=10,
+            page_increment=100,
+        )
+        x_row = Adw.SpinRow(title="X Offset (px)", adjustment=x_adj, digits=0)
+        group.add(x_row)
+
+        y_adj = Gtk.Adjustment(
+            value=y,
+            lower=-7680,
+            upper=7680,
+            step_increment=10,
+            page_increment=100,
+        )
+        y_row = Adw.SpinRow(title="Y Offset (px)", adjustment=y_adj, digits=0)
+        group.add(y_row)
+
+        def _update_visibility(*_):
+            active = enabled_row.get_active()
+            relative_row.set_visible(active)
+            x_row.set_visible(active)
+            y_row.set_visible(active)
+
+        enabled_row.connect("notify::active", _update_visibility)
+        _update_visibility()
+
+        return {
+            "enabled": enabled_row,
+            "relative": relative_row,
+            "x": x_row,
+            "y": y_row,
+        }
+
+    def _floating_position_node_from_controls(
+        self, controls: dict[str, Gtk.Widget]
+    ) -> KdlNode | None:
+        enabled_row = controls["enabled"]
+        enabled = (
+            enabled_row.get_active()
+            if isinstance(enabled_row, Adw.SwitchRow)
+            else False
+        )
+        relative_row = controls["relative"]
+        selected = (
+            relative_row.get_selected()
+            if isinstance(relative_row, Adw.ComboRow)
+            else FLOATING_POSITION_RELATIVE_TO_OPTIONS.index(
+                DEFAULT_FLOATING_POSITION_RELATIVE_TO
+            )
+        )
+        x_row = controls["x"]
+        y_row = controls["y"]
+        x = int(x_row.get_value()) if isinstance(x_row, Adw.SpinRow) else 0
+        y = int(y_row.get_value()) if isinstance(y_row, Adw.SpinRow) else 0
+        return _make_floating_position_node(
+            enabled, x, y, FLOATING_POSITION_RELATIVE_TO_OPTIONS[selected]
+        )
+
     def _show_rule_dialog(self, rule: KdlNode | None, rule_idx: int):
         dialog = Adw.Dialog(title="Window Rule")
         dialog.set_content_width(520)
@@ -285,6 +408,10 @@ class WindowRulesPage(BasePage):
             sr.set_active(_bool_action_active(rule, key))
             layout_grp.add(sr)
             bool_rows[key] = sr
+
+        floating_position_controls = self._add_floating_position_controls(
+            layout_grp, rule
+        )
 
         prefs.add(layout_grp)
 
@@ -400,6 +527,12 @@ class WindowRulesPage(BasePage):
             for key, sr in bool_rows.items():
                 if sr.get_active():
                     new_rule.children.append(_bool_action_node(key))
+
+            position_node = self._floating_position_node_from_controls(
+                floating_position_controls
+            )
+            if position_node is not None:
+                new_rule.children.append(position_node)
 
             # opacity
             op = op_row.get_value()

--- a/nirimod/pages/window_rules.py
+++ b/nirimod/pages/window_rules.py
@@ -55,17 +55,19 @@ LAYER_BOOL_ACTION_LABELS = {
 }
 
 FLOATING_POSITION_PRESETS = [
-    ("Top", 0, 0, "top"),
-    ("Bottom", 0, 0, "bottom"),
-    ("Left", 0, 0, "left"),
-    ("Right", 0, 0, "right"),
+    ("Top", "top"),
+    ("Bottom", "bottom"),
+    ("Left", "left"),
+    ("Right", "right"),
 ]
 CUSTOM_FLOATING_POSITION_LABEL = "Custom"
 FLOATING_POSITION_LOCATION_LABELS = [
-    label for label, *_ in FLOATING_POSITION_PRESETS
+    label for label, _ in FLOATING_POSITION_PRESETS
 ] + [CUSTOM_FLOATING_POSITION_LABEL]
+FLOATING_POSITION_CUSTOM_FIELD_LABELS = ["X Offset (px)", "Y Offset (px)"]
 CUSTOM_FLOATING_POSITION_INDEX = len(FLOATING_POSITION_PRESETS)
 DEFAULT_FLOATING_POSITION_RELATIVE_TO = "top"
+CUSTOM_FLOATING_POSITION_RELATIVE_TO = "top-left"
 
 
 def _bool_action_active(rule: KdlNode | None, key: str) -> bool:
@@ -119,10 +121,9 @@ def _make_floating_position_node(
 
 
 def _floating_position_location_index(x: int, y: int, relative_to: str) -> int:
-    for index, (_, preset_x, preset_y, preset_relative_to) in enumerate(
-        FLOATING_POSITION_PRESETS
-    ):
-        if (x, y, relative_to) == (preset_x, preset_y, preset_relative_to):
+    del x, y
+    for index, (_, preset_relative_to) in enumerate(FLOATING_POSITION_PRESETS):
+        if relative_to == preset_relative_to:
             return index
     return CUSTOM_FLOATING_POSITION_INDEX
 
@@ -286,7 +287,7 @@ class WindowRulesPage(BasePage):
 
     def _add_floating_position_controls(
         self, group: Adw.PreferencesGroup, rule: KdlNode | None
-    ) -> dict[str, Gtk.Widget]:
+    ) -> dict[str, Gtk.Widget | str]:
         enabled, x, y, relative_to = _floating_position_setting(rule)
 
         enabled_row = Adw.SwitchRow(
@@ -301,10 +302,6 @@ class WindowRulesPage(BasePage):
         location_row.set_selected(_floating_position_location_index(x, y, relative_to))
         group.add(location_row)
 
-        relative_row = Adw.EntryRow(title="Relative To")
-        relative_row.set_text(relative_to)
-        group.add(relative_row)
-
         x_adj = Gtk.Adjustment(
             value=x,
             lower=-7680,
@@ -312,7 +309,11 @@ class WindowRulesPage(BasePage):
             step_increment=10,
             page_increment=100,
         )
-        x_row = Adw.SpinRow(title="X Offset (px)", adjustment=x_adj, digits=0)
+        x_row = Adw.SpinRow(
+            title=FLOATING_POSITION_CUSTOM_FIELD_LABELS[0],
+            adjustment=x_adj,
+            digits=0,
+        )
         group.add(x_row)
 
         y_adj = Gtk.Adjustment(
@@ -322,31 +323,37 @@ class WindowRulesPage(BasePage):
             step_increment=10,
             page_increment=100,
         )
-        y_row = Adw.SpinRow(title="Y Offset (px)", adjustment=y_adj, digits=0)
+        y_row = Adw.SpinRow(
+            title=FLOATING_POSITION_CUSTOM_FIELD_LABELS[1],
+            adjustment=y_adj,
+            digits=0,
+        )
         group.add(y_row)
 
         def _update_visibility(*_):
             active = enabled_row.get_active()
-            custom = location_row.get_selected() == CUSTOM_FLOATING_POSITION_INDEX
             location_row.set_visible(active)
-            relative_row.set_visible(active and custom)
-            x_row.set_visible(active and custom)
-            y_row.set_visible(active and custom)
+            x_row.set_visible(active)
+            y_row.set_visible(active)
 
         enabled_row.connect("notify::active", _update_visibility)
-        location_row.connect("notify::selected", _update_visibility)
         _update_visibility()
 
+        custom_relative_to = (
+            relative_to
+            if location_row.get_selected() == CUSTOM_FLOATING_POSITION_INDEX
+            else CUSTOM_FLOATING_POSITION_RELATIVE_TO
+        )
         return {
             "enabled": enabled_row,
             "location": location_row,
-            "relative": relative_row,
             "x": x_row,
             "y": y_row,
+            "custom_relative_to": custom_relative_to,
         }
 
     def _floating_position_node_from_controls(
-        self, controls: dict[str, Gtk.Widget]
+        self, controls: dict[str, Gtk.Widget | str]
     ) -> KdlNode | None:
         enabled_row = controls["enabled"]
         enabled = (
@@ -361,15 +368,14 @@ class WindowRulesPage(BasePage):
             else CUSTOM_FLOATING_POSITION_INDEX
         )
         if selected < CUSTOM_FLOATING_POSITION_INDEX:
-            _, x, y, relative_to = FLOATING_POSITION_PRESETS[selected]
-            return _make_floating_position_node(enabled, x, y, relative_to)
-
-        relative_row = controls["relative"]
-        relative_to = (
-            relative_row.get_text()
-            if isinstance(relative_row, Adw.EntryRow)
-            else DEFAULT_FLOATING_POSITION_RELATIVE_TO
-        )
+            _, relative_to = FLOATING_POSITION_PRESETS[selected]
+        else:
+            custom_relative_to = controls.get("custom_relative_to")
+            relative_to = (
+                custom_relative_to
+                if isinstance(custom_relative_to, str)
+                else CUSTOM_FLOATING_POSITION_RELATIVE_TO
+            )
         x_row = controls["x"]
         y_row = controls["y"]
         x = int(x_row.get_value()) if isinstance(x_row, Adw.SpinRow) else 0

--- a/nirimod/pages/window_rules.py
+++ b/nirimod/pages/window_rules.py
@@ -121,7 +121,8 @@ def _make_floating_position_node(
 
 
 def _floating_position_location_index(x: int, y: int, relative_to: str) -> int:
-    del x, y
+    if x != 0 or y != 0:
+        return CUSTOM_FLOATING_POSITION_INDEX
     for index, (_, preset_relative_to) in enumerate(FLOATING_POSITION_PRESETS):
         if relative_to == preset_relative_to:
             return index
@@ -332,11 +333,13 @@ class WindowRulesPage(BasePage):
 
         def _update_visibility(*_):
             active = enabled_row.get_active()
+            custom = location_row.get_selected() == CUSTOM_FLOATING_POSITION_INDEX
             location_row.set_visible(active)
-            x_row.set_visible(active)
-            y_row.set_visible(active)
+            x_row.set_visible(active and custom)
+            y_row.set_visible(active and custom)
 
         enabled_row.connect("notify::active", _update_visibility)
+        location_row.connect("notify::selected", _update_visibility)
         _update_visibility()
 
         custom_relative_to = (
@@ -369,6 +372,7 @@ class WindowRulesPage(BasePage):
         )
         if selected < CUSTOM_FLOATING_POSITION_INDEX:
             _, relative_to = FLOATING_POSITION_PRESETS[selected]
+            return _make_floating_position_node(enabled, 0, 0, relative_to)
         else:
             custom_relative_to = controls.get("custom_relative_to")
             relative_to = (

--- a/nirimod/pages/window_rules.py
+++ b/nirimod/pages/window_rules.py
@@ -54,17 +54,18 @@ LAYER_BOOL_ACTION_LABELS = {
     SCREENCAST_BLOCK_KEY: "Block from Screencast",
 }
 
-FLOATING_POSITION_RELATIVE_TO_OPTIONS = [
-    "top-left",
-    "top-right",
-    "bottom-left",
-    "bottom-right",
-    "top",
-    "bottom",
-    "left",
-    "right",
+FLOATING_POSITION_PRESETS = [
+    ("Top", 0, 0, "top"),
+    ("Bottom", 0, 0, "bottom"),
+    ("Left", 0, 0, "left"),
+    ("Right", 0, 0, "right"),
 ]
-DEFAULT_FLOATING_POSITION_RELATIVE_TO = "top-left"
+CUSTOM_FLOATING_POSITION_LABEL = "Custom"
+FLOATING_POSITION_LOCATION_LABELS = [
+    label for label, *_ in FLOATING_POSITION_PRESETS
+] + [CUSTOM_FLOATING_POSITION_LABEL]
+CUSTOM_FLOATING_POSITION_INDEX = len(FLOATING_POSITION_PRESETS)
+DEFAULT_FLOATING_POSITION_RELATIVE_TO = "top"
 
 
 def _bool_action_active(rule: KdlNode | None, key: str) -> bool:
@@ -100,8 +101,6 @@ def _floating_position_setting(rule: KdlNode | None) -> tuple[bool, int, int, st
     relative_to = str(
         node.props.get("relative-to", DEFAULT_FLOATING_POSITION_RELATIVE_TO)
     )
-    if relative_to not in FLOATING_POSITION_RELATIVE_TO_OPTIONS:
-        relative_to = DEFAULT_FLOATING_POSITION_RELATIVE_TO
     return (True, x, y, relative_to)
 
 
@@ -110,12 +109,22 @@ def _make_floating_position_node(
 ) -> KdlNode | None:
     if not enabled:
         return None
-    if relative_to not in FLOATING_POSITION_RELATIVE_TO_OPTIONS:
+    relative_to = relative_to.strip()
+    if not relative_to:
         relative_to = DEFAULT_FLOATING_POSITION_RELATIVE_TO
     return KdlNode(
         "default-floating-position",
         props={"x": int(x), "y": int(y), "relative-to": relative_to},
     )
+
+
+def _floating_position_location_index(x: int, y: int, relative_to: str) -> int:
+    for index, (_, preset_x, preset_y, preset_relative_to) in enumerate(
+        FLOATING_POSITION_PRESETS
+    ):
+        if (x, y, relative_to) == (preset_x, preset_y, preset_relative_to):
+            return index
+    return CUSTOM_FLOATING_POSITION_INDEX
 
 
 def _rule_summary(rule: KdlNode) -> tuple[str, str]:
@@ -287,11 +296,13 @@ class WindowRulesPage(BasePage):
         enabled_row.set_active(enabled)
         group.add(enabled_row)
 
-        relative_model = Gtk.StringList.new(FLOATING_POSITION_RELATIVE_TO_OPTIONS)
-        relative_row = Adw.ComboRow(title="Relative To", model=relative_model)
-        relative_row.set_selected(
-            FLOATING_POSITION_RELATIVE_TO_OPTIONS.index(relative_to)
-        )
+        location_model = Gtk.StringList.new(FLOATING_POSITION_LOCATION_LABELS)
+        location_row = Adw.ComboRow(title="Location", model=location_model)
+        location_row.set_selected(_floating_position_location_index(x, y, relative_to))
+        group.add(location_row)
+
+        relative_row = Adw.EntryRow(title="Relative To")
+        relative_row.set_text(relative_to)
         group.add(relative_row)
 
         x_adj = Gtk.Adjustment(
@@ -316,15 +327,19 @@ class WindowRulesPage(BasePage):
 
         def _update_visibility(*_):
             active = enabled_row.get_active()
-            relative_row.set_visible(active)
-            x_row.set_visible(active)
-            y_row.set_visible(active)
+            custom = location_row.get_selected() == CUSTOM_FLOATING_POSITION_INDEX
+            location_row.set_visible(active)
+            relative_row.set_visible(active and custom)
+            x_row.set_visible(active and custom)
+            y_row.set_visible(active and custom)
 
         enabled_row.connect("notify::active", _update_visibility)
+        location_row.connect("notify::selected", _update_visibility)
         _update_visibility()
 
         return {
             "enabled": enabled_row,
+            "location": location_row,
             "relative": relative_row,
             "x": x_row,
             "y": y_row,
@@ -339,21 +354,27 @@ class WindowRulesPage(BasePage):
             if isinstance(enabled_row, Adw.SwitchRow)
             else False
         )
-        relative_row = controls["relative"]
+        location_row = controls["location"]
         selected = (
-            relative_row.get_selected()
-            if isinstance(relative_row, Adw.ComboRow)
-            else FLOATING_POSITION_RELATIVE_TO_OPTIONS.index(
-                DEFAULT_FLOATING_POSITION_RELATIVE_TO
-            )
+            location_row.get_selected()
+            if isinstance(location_row, Adw.ComboRow)
+            else CUSTOM_FLOATING_POSITION_INDEX
+        )
+        if selected < CUSTOM_FLOATING_POSITION_INDEX:
+            _, x, y, relative_to = FLOATING_POSITION_PRESETS[selected]
+            return _make_floating_position_node(enabled, x, y, relative_to)
+
+        relative_row = controls["relative"]
+        relative_to = (
+            relative_row.get_text()
+            if isinstance(relative_row, Adw.EntryRow)
+            else DEFAULT_FLOATING_POSITION_RELATIVE_TO
         )
         x_row = controls["x"]
         y_row = controls["y"]
         x = int(x_row.get_value()) if isinstance(x_row, Adw.SpinRow) else 0
         y = int(y_row.get_value()) if isinstance(y_row, Adw.SpinRow) else 0
-        return _make_floating_position_node(
-            enabled, x, y, FLOATING_POSITION_RELATIVE_TO_OPTIONS[selected]
-        )
+        return _make_floating_position_node(enabled, x, y, relative_to)
 
     def _show_rule_dialog(self, rule: KdlNode | None, rule_idx: int):
         dialog = Adw.Dialog(title="Window Rule")

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -9,11 +9,14 @@ pytest.importorskip("gi")
 
 from nirimod.kdl_parser import KdlNode, write_kdl
 from nirimod.pages.window_rules import (
+    CUSTOM_FLOATING_POSITION_INDEX,
     DEFAULT_FLOATING_POSITION_RELATIVE_TO,
+    FLOATING_POSITION_CUSTOM_FIELD_LABELS,
     FLOATING_POSITION_LOCATION_LABELS,
     SCREENCAST_BLOCK_KEY,
     _bool_action_active,
     _bool_action_node,
+    _floating_position_location_index,
     _floating_position_setting,
     _make_floating_position_node,
 )
@@ -52,6 +55,24 @@ class TestWindowRuleActions(unittest.TestCase):
         self.assertEqual(
             FLOATING_POSITION_LOCATION_LABELS,
             ["Top", "Bottom", "Left", "Right", "Custom"],
+        )
+
+    def test_floating_position_custom_fields_are_offsets_only(self):
+        self.assertEqual(
+            FLOATING_POSITION_CUSTOM_FIELD_LABELS,
+            ["X Offset (px)", "Y Offset (px)"],
+        )
+
+    def test_floating_position_edge_locations_allow_offsets(self):
+        self.assertEqual(
+            _floating_position_location_index(20, 0, "right"),
+            FLOATING_POSITION_LOCATION_LABELS.index("Right"),
+        )
+
+    def test_floating_position_custom_location_is_for_non_edge_anchors(self):
+        self.assertEqual(
+            _floating_position_location_index(12, 34, "bottom-right"),
+            CUSTOM_FLOATING_POSITION_INDEX,
         )
 
     def test_floating_position_writes_anchor_properties(self):

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -10,6 +10,7 @@ pytest.importorskip("gi")
 from nirimod.kdl_parser import KdlNode, write_kdl
 from nirimod.pages.window_rules import (
     DEFAULT_FLOATING_POSITION_RELATIVE_TO,
+    FLOATING_POSITION_LOCATION_LABELS,
     SCREENCAST_BLOCK_KEY,
     _bool_action_active,
     _bool_action_node,
@@ -47,12 +48,27 @@ class TestWindowRuleActions(unittest.TestCase):
             )
         )
 
+    def test_floating_position_locations_are_edges_plus_custom(self):
+        self.assertEqual(
+            FLOATING_POSITION_LOCATION_LABELS,
+            ["Top", "Bottom", "Left", "Right", "Custom"],
+        )
+
     def test_floating_position_writes_anchor_properties(self):
         node = _make_floating_position_node(True, 0, 0, "right")
         out = write_kdl([KdlNode("window-rule", children=[node])])
 
         self.assertIn(
             'default-floating-position x=0 y=0 relative-to="right"',
+            out,
+        )
+
+    def test_floating_position_writes_custom_offset(self):
+        node = _make_floating_position_node(True, 12, 34, "right")
+        out = write_kdl([KdlNode("window-rule", children=[node])])
+
+        self.assertIn(
+            'default-floating-position x=12 y=34 relative-to="right"',
             out,
         )
 

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -63,10 +63,16 @@ class TestWindowRuleActions(unittest.TestCase):
             ["X Offset (px)", "Y Offset (px)"],
         )
 
-    def test_floating_position_edge_locations_allow_offsets(self):
+    def test_floating_position_edge_locations_use_zero_offsets(self):
+        self.assertEqual(
+            _floating_position_location_index(0, 0, "right"),
+            FLOATING_POSITION_LOCATION_LABELS.index("Right"),
+        )
+
+    def test_floating_position_edge_offsets_are_custom(self):
         self.assertEqual(
             _floating_position_location_index(20, 0, "right"),
-            FLOATING_POSITION_LOCATION_LABELS.index("Right"),
+            CUSTOM_FLOATING_POSITION_INDEX,
         )
 
     def test_floating_position_custom_location_is_for_non_edge_anchors(self):

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import unittest
 import pytest
+
 pytest.importorskip("gi")
 
 from nirimod.kdl_parser import KdlNode, write_kdl
 from nirimod.pages.window_rules import (
+    DEFAULT_FLOATING_POSITION_RELATIVE_TO,
     SCREENCAST_BLOCK_KEY,
     _bool_action_active,
     _bool_action_node,
+    _floating_position_setting,
+    _make_floating_position_node,
 )
 
 
@@ -35,6 +39,38 @@ class TestWindowRuleActions(unittest.TestCase):
         )
 
         self.assertTrue(_bool_action_active(rule, SCREENCAST_BLOCK_KEY))
+
+    def test_floating_position_default_writes_no_override(self):
+        self.assertIsNone(
+            _make_floating_position_node(
+                False, 0, 0, DEFAULT_FLOATING_POSITION_RELATIVE_TO
+            )
+        )
+
+    def test_floating_position_writes_anchor_properties(self):
+        node = _make_floating_position_node(True, 0, 0, "right")
+        out = write_kdl([KdlNode("window-rule", children=[node])])
+
+        self.assertIn(
+            'default-floating-position x=0 y=0 relative-to="right"',
+            out,
+        )
+
+    def test_floating_position_reads_existing_anchor(self):
+        rule = KdlNode(
+            "window-rule",
+            children=[
+                KdlNode(
+                    "default-floating-position",
+                    props={"x": 12, "y": 34, "relative-to": "bottom-right"},
+                )
+            ],
+        )
+
+        self.assertEqual(
+            _floating_position_setting(rule),
+            (True, 12, 34, "bottom-right"),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- add controls for `default-floating-position` in the window-rule editor
- provide Top, Bottom, Left, and Right zero-offset presets
- show x/y offsets only for Custom positions
- preserve existing offset or non-edge anchor rules as Custom
- omit the node when the position override is disabled

<img width="500" height="345" alt="annotate-2026-05-01T14-11-00" src="https://github.com/user-attachments/assets/1ed97144-921e-428d-892e-cbfaca345acc" />

