### PR TITLE
Make update checks branch aware

### DIFF
--- a/nirimod/updater.py
+++ b/nirimod/updater.py
@@ -28,8 +28,8 @@ def check_for_updates(callback):
     def _do_check():
         try:
             from gi.repository import GLib
-            if not os.path.isdir(os.path.join(INSTALL_DIR, ".git")):
 
+            if not os.path.isdir(os.path.join(INSTALL_DIR, ".git")):
                 GLib.idle_add(callback, None, None)
                 return
 
@@ -49,7 +49,7 @@ def check_for_updates(callback):
                     "message", "New update available"
                 )
 
-            if remote_hash and remote_hash != local_hash:
+            if _update_available(local_hash, remote_hash, INSTALL_DIR):
                 GLib.idle_add(callback, remote_hash, commit_msg)
             else:
                 GLib.idle_add(callback, None, None)
@@ -59,6 +59,27 @@ def check_for_updates(callback):
             GLib.idle_add(callback, None, None)
 
     threading.Thread(target=_do_check, daemon=True).start()
+
+
+def _commit_is_ancestor(commit_hash: str, install_dir: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", commit_hash, "HEAD"],
+        cwd=install_dir,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _update_available(
+    local_hash: str, remote_hash: str | None, install_dir: str = INSTALL_DIR
+) -> bool:
+    if not remote_hash or remote_hash == local_hash:
+        return False
+    if _commit_is_ancestor(remote_hash, install_dir):
+        return False
+    return True
 
 
 def _terminal_candidates():

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import tempfile
 import pytest
+
 pytest.importorskip("gi")
 
 import unittest
@@ -49,6 +51,49 @@ class TestBuildTerminalCommand(unittest.TestCase):
         command = updater._build_terminal_command("ghostty '", "/tmp/update.sh")
 
         self.assertIsNone(command)
+
+
+class TestUpdateAvailability(unittest.TestCase):
+    def _run_git(self, repo: str, *args: str):
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _commit(self, repo: str, message: str) -> str:
+        self._run_git(repo, "commit", "--allow-empty", "-m", message)
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+        ).strip()
+
+    def _make_repo(self) -> str:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        repo = temp_dir.name
+        self._run_git(repo, "init")
+        self._run_git(repo, "config", "user.email", "test@example.com")
+        self._run_git(repo, "config", "user.name", "Test User")
+        return repo
+
+    def test_branch_ahead_of_remote_main_is_not_update(self):
+        repo = self._make_repo()
+        remote_hash = self._commit(repo, "remote main")
+        local_hash = self._commit(repo, "local branch")
+
+        self.assertFalse(updater._update_available(local_hash, remote_hash, repo))
+
+    def test_dirty_worktree_still_gets_remote_update(self):
+        repo = self._make_repo()
+        local_hash = self._commit(repo, "installed version")
+        remote_hash = self._commit(repo, "remote main")
+        self._run_git(repo, "checkout", "--detach", local_hash)
+        with open(os.path.join(repo, "local-change.txt"), "w") as fh:
+            fh.write("local edit\n")
+
+        self.assertTrue(updater._update_available(local_hash, remote_hash, repo))
 
 
 class TestLaunchUpdaterInTerminal(unittest.TestCase):


### PR DESCRIPTION
- suppress update prompts when the installed checkout already contains upstream `main`
- keep prompting when upstream `main` has commits the installed checkout does not contain
- add coverage showing dirty local files do not suppress real upstream updates

## Testing
- `uv run pytest tests/test_updater.py`
- `uv run pytest tests/test_kdl_parser.py tests/test_state.py tests/test_window_effects.py tests/test_window_rules.py tests/test_updater.py tests/test_ipc.py`
- `uv run python tests/test_features.py`
- `uv run --with ruff ruff check --fix nirimod/updater.py tests/test_updater.py`
- `uv run --with ruff ruff format --check nirimod/updater.py tests/test_updater.py`