### PR TITLE
quick fix for blur

### DIFF
--- a/nirimod/kdl_parser.py
+++ b/nirimod/kdl_parser.py
@@ -743,15 +743,19 @@ def remove_child(parent: KdlNode, child_name: str) -> None:
 
 def set_node_flag(parent: KdlNode, flag_name: str, enabled: bool) -> None:
     existing = parent.get_child(flag_name)
-    if enabled and existing is None:
+    if enabled:
+        if existing is not None:
+            existing.args = []
+            existing.props = {}
+            return
         cache = getattr(parent, "_removed_children", {})
         if flag_name in cache:
             idx, node = cache[flag_name]
-            if not node.args:
-                node.args = [True]
+            node.args = []
+            node.props = {}
             parent.children.insert(min(idx, len(parent.children)), node)
         else:
-            new_node = KdlNode(name=flag_name, args=[True])
+            new_node = KdlNode(name=flag_name)
             new_node.leading_trivia = "\n"
             parent.children.insert(0, new_node)
     elif not enabled and existing is not None:

--- a/nirimod/niri_ipc.py
+++ b/nirimod/niri_ipc.py
@@ -116,6 +116,15 @@ def validate_config(config_path: str | None = None) -> tuple[bool, str]:
     return False, stderr.strip() or stdout.strip() or "Unknown validation error."
 
 
+def load_config_file() -> tuple[bool, str]:
+    stdout, stderr, rc = _run_sync(
+        ["niri", "msg", "action", "load-config-file"], timeout=10.0
+    )
+    if rc == 0:
+        return True, stdout.strip() or "Config applied."
+    return False, stderr.strip() or stdout.strip() or "Config reload failed."
+
+
 def get_outputs(callback: Callable[[list[dict]], None]) -> None:
     def _done(stdout: str, _stderr: str, rc: int) -> None:
         if rc != 0:

--- a/nirimod/pages/appearance.py
+++ b/nirimod/pages/appearance.py
@@ -12,6 +12,7 @@ from gi.repository import Adw, Gdk, Gtk
 from nirimod.kdl_parser import KdlNode, find_or_create, set_child_arg, set_node_flag
 from nirimod.pages.base import BasePage
 from nirimod.window_effects import (
+    blur_effects_enabled,
     focused_window_blur_enabled,
     get_global_draw_border_with_background,
     get_global_corner_radius,
@@ -24,6 +25,7 @@ from nirimod.window_effects import (
     set_global_window_blur,
     set_global_window_opacity,
     set_global_window_xray,
+    set_blur_effects_enabled,
 )
 
 
@@ -136,8 +138,19 @@ class AppearancePage(BasePage):
         )
         blur_node = next((n for n in nodes if n.name == "blur"), None)
 
+        blur_effects_row = Adw.SwitchRow(
+            title="Enable Blur Effects",
+            subtitle="Controls the compositor-level blur { off } setting",
+        )
+        blur_effects_row.set_active(blur_effects_enabled(nodes))
+        blur_effects_row.connect(
+            "notify::active",
+            lambda r, _: self._set_blur_effects_enabled(r.get_active()),
+        )
+        blur_grp.add(blur_effects_row)
+
         blur_enabled_row = Adw.SwitchRow(
-            title="Enable Window Blur",
+            title="Force Blur on Windows",
             subtitle="Adds background-effect { blur true } to the global window rule",
         )
         blur_enabled_row.set_active(global_window_blur_enabled(nodes))
@@ -204,7 +217,7 @@ class AppearancePage(BasePage):
             value=passes_val, lower=0, upper=10, step_increment=1
         )
         passes_row = Adw.SpinRow(
-            title="Passes (0 = disabled)", adjustment=passes_adj, digits=0
+            title="Passes", adjustment=passes_adj, digits=0
         )
 
         passes_row._last_val = passes_val
@@ -401,16 +414,13 @@ class AppearancePage(BasePage):
         self._commit("shadow color")
 
     def _set_blur(self, prop: str, value):
-
-        if prop == "passes" and int(value) == 0:
-            blur_node = next((n for n in self._nodes if n.name == "blur"), None)
-            if blur_node is not None:
-                self._nodes.remove(blur_node)
-            self._commit("blur removed")
-            return
         blur_node = find_or_create(self._nodes, "blur")
         set_child_arg(blur_node, prop, value)
         self._commit(f"blur {prop}")
+
+    def _set_blur_effects_enabled(self, enabled: bool):
+        set_blur_effects_enabled(self._nodes, enabled)
+        self._commit("blur effects")
 
     def _set_window_blur_enabled(self, enabled: bool):
         set_global_window_blur(self._nodes, enabled)

--- a/nirimod/window.py
+++ b/nirimod/window.py
@@ -563,6 +563,22 @@ class NiriModWindow(Adw.ApplicationWindow):
 
     def _on_save(self):
         new_kdl = self.app_state.write_current_kdl()
+
+        def _finish_save(reload_result):
+            reload_ok, reload_msg = reload_result
+            self.app_state.commit_save(new_kdl)
+            raw = self._pages.get("raw_config")
+            if raw and hasattr(raw, "refresh"):
+                raw.refresh()
+                self._build_search_index()
+            self.mark_clean()
+            if reload_ok:
+                self.show_toast("Config saved and applied ✓", timeout=3)
+            else:
+                self.show_toast(
+                    f"Config saved, but reload failed: {reload_msg}", timeout=8
+                )
+
         if self.app_state.is_multi_file:
             # Snapshot all source files before touching them
             snapshots = {
@@ -578,13 +594,7 @@ class NiriModWindow(Adw.ApplicationWindow):
                         p.write_text(text)
                     self.show_toast(f"Validation error: {msg}", timeout=8)
                     return
-                self.app_state.commit_save(new_kdl)
-                raw = self._pages.get("raw_config")
-                if raw and hasattr(raw, "refresh"):
-                    raw.refresh()
-                    self._build_search_index()
-                self.mark_clean()
-                self.show_toast("Config saved and applied ✓", timeout=3)
+                niri_ipc.run_in_thread(niri_ipc.load_config_file, _finish_save)
 
             niri_ipc.run_in_thread(
                 lambda: niri_ipc.validate_config(), _on_validated
@@ -600,13 +610,7 @@ class NiriModWindow(Adw.ApplicationWindow):
                     tmp_kdl.unlink(missing_ok=True)
                     return
                 shutil.move(tmp_kdl, NIRI_CONFIG)
-                self.app_state.commit_save(new_kdl)
-                raw = self._pages.get("raw_config")
-                if raw and hasattr(raw, "refresh"):
-                    raw.refresh()
-                    self._build_search_index()
-                self.mark_clean()
-                self.show_toast("Config saved and applied ✓", timeout=3)
+                niri_ipc.run_in_thread(niri_ipc.load_config_file, _finish_save)
 
             niri_ipc.run_in_thread(
                 lambda: niri_ipc.validate_config(str(tmp_kdl)), _on_validated
@@ -677,7 +681,8 @@ class NiriModWindow(Adw.ApplicationWindow):
 
     def _check_kofi(self):
         from nirimod import app_settings
-        import subprocess, os
+        import os
+        import subprocess
         from nirimod.updater import INSTALL_DIR
         
 

--- a/nirimod/window.py
+++ b/nirimod/window.py
@@ -681,24 +681,6 @@ class NiriModWindow(Adw.ApplicationWindow):
 
     def _check_kofi(self):
         from nirimod import app_settings
-        import os
-        import subprocess
-        from nirimod.updater import INSTALL_DIR
-        
-
-        current_hash = ""
-        try:
-            if os.path.isdir(os.path.join(INSTALL_DIR, ".git")):
-                current_hash = subprocess.check_output(
-                    ["git", "rev-parse", "HEAD"], cwd=INSTALL_DIR, text=True, stderr=subprocess.DEVNULL
-                ).strip()
-        except Exception:
-            pass
-            
-        last_hash = app_settings.get("kofi_last_hash", "")
-        if current_hash and current_hash != last_hash:
-            app_settings.set("kofi_last_hash", current_hash)
-            app_settings.set("kofi_dont_show", False)
 
         if app_settings.get("kofi_dont_show", False):
             return

--- a/nirimod/window_effects.py
+++ b/nirimod/window_effects.py
@@ -171,7 +171,12 @@ def set_blur_effects_enabled(nodes: list[KdlNode], enabled: bool) -> None:
     set_node_flag(blur, "off", not enabled)
     _finalize_blur_config(blur)
     _remove_rule_if_empty(nodes, blur)
-    if not enabled:
+    if enabled:
+        rule = _ensure_global_window_rule(nodes)
+        if _rule_opacity(rule) >= 1.0:
+            set_child_arg(rule, "opacity", 0.9)
+        _finalize_window_rule(rule)
+    else:
         set_global_window_blur(nodes, False)
         set_focused_window_blur(nodes, False)
 

--- a/nirimod/window_effects.py
+++ b/nirimod/window_effects.py
@@ -196,6 +196,8 @@ def _rule_blur_enabled(rule: KdlNode | None) -> bool:
 def set_global_window_blur(nodes: list[KdlNode], enabled: bool) -> None:
     if enabled:
         rule = _ensure_global_window_rule(nodes)
+        if _rule_opacity(rule) >= 1.0:
+            set_child_arg(rule, "opacity", 0.9)
         effect = _ensure_background_effect(rule)
         set_child_arg(effect, "blur", True)
         _finalize_window_rule(rule)

--- a/nirimod/window_effects.py
+++ b/nirimod/window_effects.py
@@ -171,6 +171,9 @@ def set_blur_effects_enabled(nodes: list[KdlNode], enabled: bool) -> None:
     set_node_flag(blur, "off", not enabled)
     _finalize_blur_config(blur)
     _remove_rule_if_empty(nodes, blur)
+    if not enabled:
+        set_global_window_blur(nodes, False)
+        set_focused_window_blur(nodes, False)
 
 
 def global_window_blur_enabled(nodes: list[KdlNode]) -> bool:
@@ -210,6 +213,7 @@ def set_global_window_blur(nodes: list[KdlNode], enabled: bool) -> None:
     if existing_effect is not None:
         remove_child(existing_effect, "blur")
         _remove_background_effect_if_empty(existing_rule)
+    remove_child(existing_rule, "opacity")
     _finalize_window_rule(existing_rule)
     _remove_rule_if_empty(nodes, existing_rule)
 

--- a/nirimod/window_effects.py
+++ b/nirimod/window_effects.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from nirimod.kdl_parser import KdlNode, remove_child, set_child_arg
+from nirimod.kdl_parser import KdlNode, remove_child, set_child_arg, set_node_flag
 
 _RULE_CHILD_ORDER = [
     "match",
@@ -15,6 +15,7 @@ _RULE_CHILD_ORDER = [
 ]
 
 _EFFECT_CHILD_ORDER = ["blur", "xray"]
+_BLUR_CONFIG_CHILD_ORDER = ["off", "passes", "offset", "noise", "saturation"]
 
 
 def _is_global_window_rule(node: KdlNode) -> bool:
@@ -41,6 +42,19 @@ def _global_window_rule(nodes: list[KdlNode]) -> KdlNode | None:
 
 def _focused_window_rule(nodes: list[KdlNode]) -> KdlNode | None:
     return next((n for n in reversed(nodes) if _is_focused_window_rule(n)), None)
+
+
+def _blur_config_node(nodes: list[KdlNode]) -> KdlNode | None:
+    return next((n for n in reversed(nodes) if n.name == "blur"), None)
+
+
+def _ensure_blur_config_node(nodes: list[KdlNode]) -> KdlNode:
+    blur = _blur_config_node(nodes)
+    if blur is None:
+        blur = KdlNode("blur")
+        blur.leading_trivia = "\n"
+        nodes.append(blur)
+    return blur
 
 
 def _ensure_global_window_rule(nodes: list[KdlNode]) -> KdlNode:
@@ -115,6 +129,11 @@ def _finalize_window_rule(rule: KdlNode) -> None:
     _compact_generated_spacing(rule)
 
 
+def _finalize_blur_config(blur: KdlNode) -> None:
+    _sort_children_by_name(blur, _BLUR_CONFIG_CHILD_ORDER)
+    _compact_generated_spacing(blur)
+
+
 def _rule_opacity(rule: KdlNode | None) -> float:
     if rule is None:
         return 1.0
@@ -140,6 +159,18 @@ def set_global_draw_border_with_background(nodes: list[KdlNode], enabled: bool) 
         set_child_arg(rule, "draw-border-with-background", False)
     _finalize_window_rule(rule)
     _remove_rule_if_empty(nodes, rule)
+
+
+def blur_effects_enabled(nodes: list[KdlNode]) -> bool:
+    blur = _blur_config_node(nodes)
+    return blur is None or blur.get_child("off") is None
+
+
+def set_blur_effects_enabled(nodes: list[KdlNode], enabled: bool) -> None:
+    blur = _ensure_blur_config_node(nodes)
+    set_node_flag(blur, "off", not enabled)
+    _finalize_blur_config(blur)
+    _remove_rule_if_empty(nodes, blur)
 
 
 def global_window_blur_enabled(nodes: list[KdlNode]) -> bool:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,7 +7,7 @@ import os
 os.environ.setdefault("DISPLAY", ":0")
 os.environ.setdefault("WAYLAND_DISPLAY", "wayland-1")
 
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 PASS = "[PASS]"
 WARN = "[WARN]"
 FAIL = "[FAIL]"
@@ -22,13 +22,15 @@ def test(name, fn):
         results.append((FAIL, name, f"{type(e).__name__}: {e}"))
         traceback.print_exc()
 
+
+test.__test__ = False
+
 # KDL Parser
 from nirimod.kdl_parser import parse_kdl, write_kdl, KdlNode
 
 def t_kdl_roundtrip():
     src = 'output "eDP-1" { scale 2.0; }\nbinds { XF86AudioRaise { action "volume-up"; } }'
     nodes = parse_kdl(src)
-    out = write_kdl(nodes)
     assert nodes, "no nodes parsed"
     return f"{len(nodes)} nodes"
 
@@ -164,7 +166,7 @@ page_modules = [
 import importlib
 for name, module_path in page_modules:
     def _test(mp=module_path, n=name):
-        mod = importlib.import_module(mp)
+        importlib.import_module(mp)
         return "module imported OK"
     test(f"Page import: {name}", _test)
 
@@ -173,7 +175,6 @@ import shlex
 
 def t_startup_spawn_sh():
     cmd = "waybar --config /etc/waybar.json"
-    args = shlex.split(cmd)
     node = KdlNode("spawn-sh-at-startup", args=[cmd])   # single string for sh
     assert node.args[0] == cmd
     return f"spawn-sh-at-startup args = {node.args}"
@@ -276,30 +277,35 @@ from nirimod import app_settings
 def t_app_settings():
     original = app_settings.get("auto_update", True)
     app_settings.set("auto_update", False)
-    assert app_settings.get("auto_update") == False
+    assert not app_settings.get("auto_update")
     app_settings.set("auto_update", original)
     return "get/set OK"
 
 test("AppSettings: get/set", t_app_settings)
 
-# Print Results
-print("\n" + "="*50)
-print("  NIRIMOD FEATURE TEST REPORT")
-print("="*50)
+def _print_results() -> int:
+    print("\n" + "="*50)
+    print("  NIRIMOD FEATURE TEST REPORT")
+    print("="*50)
 
-passed = sum(1 for r in results if r[0] == PASS)
-failed = sum(1 for r in results if r[0] == FAIL)
-warned = sum(1 for r in results if r[0] == WARN)
+    passed = sum(1 for r in results if r[0] == PASS)
+    failed = sum(1 for r in results if r[0] == FAIL)
+    warned = sum(1 for r in results if r[0] == WARN)
 
-for icon, name, detail in results:
-    status = f"{icon} {name}"
-    if detail:
-        print(f"{status}\n     → {detail}")
-    else:
-        print(status)
+    for icon, name, detail in results:
+        status = f"{icon} {name}"
+        if detail:
+            print(f"{status}\n     → {detail}")
+        else:
+            print(status)
 
-print("="*50)
-print(f"  {passed} passed  |  {warned} warnings  |  {failed} failed  |  {len(results)} total")
-print("="*50)
+    print("="*50)
+    print(
+        f"  {passed} passed  |  {warned} warnings  |  {failed} failed  |  {len(results)} total"
+    )
+    print("="*50)
+    return failed
 
-sys.exit(1 if failed else 0)
+
+if __name__ == "__main__":
+    sys.exit(1 if _print_results() else 0)

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -83,6 +83,35 @@ class TestValidateConfig(unittest.TestCase):
         self.assertIn("/tmp/test.kdl", captured["args"])
 
 
+class TestLoadConfigFile(unittest.TestCase):
+    def test_load_config_file_calls_niri_action(self):
+        from nirimod import niri_ipc
+
+        captured = {}
+
+        def fake_run(args, timeout=5.0):
+            captured["args"] = args
+            captured["timeout"] = timeout
+            return ("", "", 0)
+
+        with patch.object(niri_ipc, "_run_sync", side_effect=fake_run):
+            ok, msg = niri_ipc.load_config_file()
+
+        self.assertTrue(ok)
+        self.assertEqual(captured["args"], ["niri", "msg", "action", "load-config-file"])
+        self.assertEqual(captured["timeout"], 10.0)
+        self.assertIn("applied", msg)
+
+    def test_load_config_file_reports_failure(self):
+        from nirimod import niri_ipc
+
+        with patch.object(niri_ipc, "_run_sync", return_value=("", "reload failed", 1)):
+            ok, msg = niri_ipc.load_config_file()
+
+        self.assertFalse(ok)
+        self.assertIn("reload failed", msg)
+
+
 class TestHasTouchpad(unittest.TestCase):
     def test_caching(self):
         import nirimod.niri_ipc as ipc_mod

--- a/tests/test_kdl_parser.py
+++ b/tests/test_kdl_parser.py
@@ -138,12 +138,31 @@ class TestMutationHelpers(unittest.TestCase):
         parent = KdlNode("input")
         set_node_flag(parent, "warp-mouse-to-focus", True)
         self.assertIsNotNone(parent.get_child("warp-mouse-to-focus"))
+        self.assertEqual(parent.get_child("warp-mouse-to-focus").args, [])
+
+    def test_set_node_flag_serializes_bare_flag(self):
+        parent = KdlNode("blur")
+
+        set_node_flag(parent, "off", True)
+
+        self.assertIn("off", write_kdl([parent]))
+        self.assertNotIn("off true", write_kdl([parent]))
 
     def test_set_node_flag_remove(self):
         parent = KdlNode("input")
         parent.children.append(KdlNode("warp-mouse-to-focus"))
         set_node_flag(parent, "warp-mouse-to-focus", False)
         self.assertIsNone(parent.get_child("warp-mouse-to-focus"))
+
+    def test_set_node_flag_restores_bare_flag(self):
+        parent = KdlNode("blur")
+        parent.children.append(KdlNode("off"))
+
+        set_node_flag(parent, "off", False)
+        set_node_flag(parent, "off", True)
+
+        self.assertIn("off", write_kdl([parent]))
+        self.assertNotIn("off true", write_kdl([parent]))
 
     def test_set_node_flag_idempotent_add(self):
         parent = KdlNode("input")

--- a/tests/test_window_effects.py
+++ b/tests/test_window_effects.py
@@ -6,6 +6,7 @@ import unittest
 
 from nirimod.kdl_parser import KdlNode, parse_kdl, write_kdl
 from nirimod.window_effects import (
+    blur_effects_enabled,
     focused_window_blur_enabled,
     get_global_draw_border_with_background,
     get_global_corner_radius,
@@ -18,10 +19,76 @@ from nirimod.window_effects import (
     set_global_window_blur,
     set_global_window_opacity,
     set_global_window_xray,
+    set_blur_effects_enabled,
 )
 
 
 class TestGlobalWindowEffects(unittest.TestCase):
+    def test_blur_effects_are_enabled_without_top_level_off(self):
+        nodes = parse_kdl(
+            """
+blur {
+    passes 3
+    offset 3
+}
+"""
+        )
+
+        self.assertTrue(blur_effects_enabled(nodes))
+
+    def test_disabling_blur_effects_writes_top_level_off(self):
+        nodes: list[KdlNode] = []
+
+        set_blur_effects_enabled(nodes, False)
+
+        out = write_kdl(nodes)
+        self.assertIn("blur", out)
+        self.assertIn("off", out)
+        self.assertNotIn("off true", out)
+        self.assertFalse(blur_effects_enabled(nodes))
+
+    def test_disabling_blur_effects_preserves_quality_settings(self):
+        nodes = parse_kdl(
+            """
+blur {
+    passes 3
+    offset 3
+    noise 0.02
+    saturation 1.5
+}
+"""
+        )
+
+        set_blur_effects_enabled(nodes, False)
+
+        out = write_kdl(nodes)
+        self.assertIn("off", out)
+        self.assertIn("passes 3", out)
+        self.assertIn("offset 3", out)
+        self.assertIn("noise 0.02", out)
+        self.assertIn("saturation 1.5", out)
+        self.assertNotIn("off true", out)
+
+    def test_enabling_blur_effects_removes_only_off(self):
+        nodes = parse_kdl(
+            """
+blur {
+    off
+    passes 3
+    offset 3
+}
+"""
+        )
+
+        set_blur_effects_enabled(nodes, True)
+
+        out = write_kdl(nodes)
+        blur = parse_kdl(out)[0]
+        self.assertIsNone(blur.get_child("off"))
+        self.assertIn("passes 3", out)
+        self.assertIn("offset 3", out)
+        self.assertTrue(blur_effects_enabled(nodes))
+
     def test_enabling_blur_creates_matchless_window_rule(self):
         nodes: list[KdlNode] = []
 

--- a/tests/test_window_effects.py
+++ b/tests/test_window_effects.py
@@ -147,6 +147,60 @@ window-rule {
         self.assertIsNotNone(rule.get_child("background-effect").get_child("xray"))
         self.assertFalse(global_window_blur_enabled(nodes))
 
+    def test_disabling_blur_resets_window_opacity(self):
+        nodes = parse_kdl(
+            """
+window-rule {
+    opacity 0.95
+    background-effect {
+        blur true
+        xray false
+    }
+}
+"""
+        )
+
+        set_global_window_blur(nodes, False)
+
+        rule = nodes[0]
+        self.assertEqual(get_global_window_opacity(nodes), 1.0)
+        self.assertIsNone(rule.get_child("opacity"))
+        self.assertIsNone(rule.get_child("background-effect").get_child("blur"))
+        self.assertIsNotNone(rule.get_child("background-effect").get_child("xray"))
+
+    def test_disabling_blur_effects_clears_forced_blur_and_opacity(self):
+        nodes = parse_kdl(
+            """
+blur {
+    passes 3
+}
+window-rule {
+    opacity 0.9
+    background-effect {
+        blur true
+        xray false
+    }
+}
+window-rule {
+    match is-focused=true
+    background-effect {
+        blur true
+    }
+}
+"""
+        )
+
+        set_blur_effects_enabled(nodes, False)
+
+        out = write_kdl(nodes)
+        self.assertIn("off", out)
+        self.assertFalse(blur_effects_enabled(nodes))
+        self.assertFalse(global_window_blur_enabled(nodes))
+        self.assertFalse(focused_window_blur_enabled(nodes))
+        self.assertEqual(get_global_window_opacity(nodes), 1.0)
+        self.assertNotIn("blur true", out)
+        self.assertNotIn("opacity 0.9", out)
+
     def test_corner_radius_writes_clip_and_can_be_removed(self):
         nodes: list[KdlNode] = []
 

--- a/tests/test_window_effects.py
+++ b/tests/test_window_effects.py
@@ -89,6 +89,40 @@ blur {
         self.assertIn("offset 3", out)
         self.assertTrue(blur_effects_enabled(nodes))
 
+    def test_enabling_blur_effects_sets_visible_default_opacity_when_unset(self):
+        nodes = parse_kdl(
+            """
+blur {
+    off
+    passes 3
+}
+"""
+        )
+
+        set_blur_effects_enabled(nodes, True)
+
+        out = write_kdl(nodes)
+        self.assertEqual(get_global_window_opacity(nodes), 0.9)
+        self.assertIn("opacity 0.9", out)
+
+    def test_enabling_blur_effects_preserves_existing_opacity(self):
+        nodes = parse_kdl(
+            """
+blur {
+    off
+    passes 3
+}
+window-rule {
+    opacity 0.75
+}
+"""
+        )
+
+        set_blur_effects_enabled(nodes, True)
+
+        self.assertEqual(get_global_window_opacity(nodes), 0.75)
+        self.assertIn("opacity 0.75", write_kdl(nodes))
+
     def test_enabling_blur_creates_matchless_window_rule(self):
         nodes: list[KdlNode] = []
 

--- a/tests/test_window_effects.py
+++ b/tests/test_window_effects.py
@@ -101,6 +101,28 @@ blur {
         self.assertNotIn("draw-border-with-background", out)
         self.assertTrue(global_window_blur_enabled(nodes))
 
+    def test_enabling_blur_sets_visible_default_opacity_when_unset(self):
+        nodes: list[KdlNode] = []
+
+        set_global_window_blur(nodes, True)
+
+        self.assertEqual(get_global_window_opacity(nodes), 0.9)
+        self.assertIn("opacity 0.9", write_kdl(nodes))
+
+    def test_enabling_blur_preserves_existing_opacity(self):
+        nodes = parse_kdl(
+            """
+window-rule {
+    opacity 0.75
+}
+"""
+        )
+
+        set_global_window_blur(nodes, True)
+
+        self.assertEqual(get_global_window_opacity(nodes), 0.75)
+        self.assertIn("opacity 0.75", write_kdl(nodes))
+
     def test_disabling_blur_preserves_other_window_effect_settings(self):
         nodes = parse_kdl(
             """


### PR DESCRIPTION
This fixes blur controls by applying saved niri config changes immediately and keeping window opacity in sync so blur visibly turns on and off.