### PR TITLE
feat(startup): add delay setting

### DIFF
--- a/nirimod/pages/startup.py
+++ b/nirimod/pages/startup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 
-import shlex
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -12,6 +11,7 @@ from gi.repository import Adw, Gtk, GLib
 
 from nirimod.kdl_parser import KdlNode
 from nirimod.pages.base import BasePage
+from nirimod.startup_entries import make_startup_node, startup_values_from_node
 
 
 class StartupPage(BasePage):
@@ -84,13 +84,18 @@ class StartupPage(BasePage):
             self._content.append(add_btn)
 
     def _make_row(self, node: KdlNode, idx: int) -> Adw.ActionRow:
-        cmd = " ".join(str(a) for a in node.args)
-        is_sh = "sh" in node.name
+        cmd, is_sh, delay = startup_values_from_node(node)
         cmd_str = GLib.markup_escape_text(cmd) if cmd else "(empty)"
+        subtitle_parts = []
+        if delay > 0:
+            subtitle_parts.append(f"Delay: {delay}s")
+        subtitle_parts.append(
+            "Via shell (spawn-sh-at-startup)" if is_sh else "Launched directly"
+        )
 
         row = Adw.ActionRow(
             title=cmd_str or "(empty)",
-            subtitle="Via shell (spawn-sh-at-startup)" if is_sh else "Launched directly",
+            subtitle=" | ".join(subtitle_parts),
         )
         row.set_activatable(True)
         row.connect("activated", lambda *_, i=idx: self._on_edit(i))
@@ -125,13 +130,25 @@ class StartupPage(BasePage):
         )
         cmd_entry = Adw.EntryRow(title="Command")
         sh_switch = Adw.SwitchRow(title="Use shell (spawn-sh-at-startup)")
+        delay_adj = Gtk.Adjustment(
+            value=0, lower=0, upper=3600, step_increment=1, page_increment=10
+        )
+        delay_row = Adw.SpinRow(
+            title="Delay",
+            subtitle="Seconds to wait before launching",
+            adjustment=delay_adj,
+            digits=0,
+        )
         if node:
-            cmd_entry.set_text(" ".join(str(a) for a in node.args))
-            sh_switch.set_active("sh" in node.name)
+            command, is_sh, delay = startup_values_from_node(node)
+            cmd_entry.set_text(command)
+            sh_switch.set_active(is_sh)
+            delay_row.set_value(delay)
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
         grp = Adw.PreferencesGroup()
         grp.add(cmd_entry)
+        grp.add(delay_row)
         grp.add(sh_switch)
         box.append(grp)
         dialog.set_extra_child(box)
@@ -147,17 +164,8 @@ class StartupPage(BasePage):
             if not cmd:
                 return
             is_sh = sh_switch.get_active()
-            node_name = "spawn-sh-at-startup" if is_sh else "spawn-at-startup"
-            if is_sh:
-                # sh -c expects a single string; store the whole command as one arg
-                args = [cmd]
-            else:
-                try:
-                    args = shlex.split(cmd)
-                except ValueError:
-                    args = cmd.split()
-
-            new_node = KdlNode(node_name, args=args)
+            delay = int(delay_row.get_value())
+            new_node = make_startup_node(cmd, is_sh, delay)
             entries = self._get_entries()
             if idx >= 0 and 0 <= idx < len(entries):
                 i = self._nodes.index(entries[idx])

--- a/nirimod/startup_entries.py
+++ b/nirimod/startup_entries.py
@@ -1,0 +1,57 @@
+"""Helpers for reading and writing startup program entries."""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+from nirimod.kdl_parser import KdlNode
+
+
+_DELAY_PREFIX_RE = re.compile(
+    r"^\s*sleep\s+(?P<seconds>\d+)\s*(?:&&|;)\s*(?P<command>.+?)\s*$"
+)
+
+
+def strip_startup_delay(command: str) -> tuple[str, int]:
+    match = _DELAY_PREFIX_RE.match(command)
+    if match is None:
+        return command, 0
+
+    command = match.group("command").strip()
+    if command.startswith("exec "):
+        command = command[5:].strip()
+    return command, int(match.group("seconds"))
+
+
+def startup_values_from_node(node: KdlNode) -> tuple[str, bool, int]:
+    is_sh = "sh" in node.name
+    if is_sh:
+        command = str(node.args[0]) if node.args else ""
+        command, delay = strip_startup_delay(command)
+        return command, True, delay
+
+    command = shlex.join(str(arg) for arg in node.args)
+    return command, False, 0
+
+
+def make_startup_node(command: str, is_sh: bool, delay: int) -> KdlNode:
+    if delay > 0:
+        if is_sh:
+            delayed_command = f"sleep {delay} && {command}"
+        else:
+            try:
+                args = shlex.split(command)
+            except ValueError:
+                args = command.split()
+            delayed_command = f"sleep {delay} && exec {shlex.join(args)}"
+        return KdlNode("spawn-sh-at-startup", args=[delayed_command])
+
+    if is_sh:
+        return KdlNode("spawn-sh-at-startup", args=[command])
+
+    try:
+        args = shlex.split(command)
+    except ValueError:
+        args = command.split()
+    return KdlNode("spawn-at-startup", args=args)

--- a/tests/test_startup_entries.py
+++ b/tests/test_startup_entries.py
@@ -1,0 +1,47 @@
+"""Unit tests for startup program entry helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from nirimod.kdl_parser import KdlNode
+from nirimod.startup_entries import make_startup_node, startup_values_from_node
+
+
+class TestStartupEntryDelay(unittest.TestCase):
+    def test_delay_wraps_direct_command_as_shell_entry(self):
+        node = make_startup_node("waybar --config /etc/waybar.json", False, 7)
+
+        self.assertEqual(node.name, "spawn-sh-at-startup")
+        self.assertEqual(node.args, ["sleep 7 && exec waybar --config /etc/waybar.json"])
+
+    def test_delayed_direct_command_can_be_edited_without_sleep_prefix(self):
+        node = KdlNode(
+            "spawn-sh-at-startup",
+            args=["sleep 12 && exec alacritty --class scratch"],
+        )
+
+        command, is_sh, delay = startup_values_from_node(node)
+
+        self.assertEqual(command, "alacritty --class scratch")
+        self.assertTrue(is_sh)
+        self.assertEqual(delay, 12)
+
+    def test_shell_command_delay_preserves_shell_syntax(self):
+        node = make_startup_node("echo $PATH | grep local", True, 3)
+
+        self.assertEqual(node.name, "spawn-sh-at-startup")
+        self.assertEqual(node.args, ["sleep 3 && echo $PATH | grep local"])
+
+    def test_direct_entry_form_text_quotes_arguments_with_spaces(self):
+        node = KdlNode("spawn-at-startup", args=["launcher", "--name", "My App"])
+
+        command, is_sh, delay = startup_values_from_node(node)
+
+        self.assertEqual(command, "launcher --name 'My App'")
+        self.assertFalse(is_sh)
+        self.assertEqual(delay, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes delay settings for autostart entries configurable from GUI by adding `sleep x &&` before the launch command.

<img width="487" height="417" alt="annotate-2026-05-28T19-46-23" src="https://github.com/user-attachments/assets/2ad3bdc3-6db9-488c-be98-24c713602ebf" />
