### PR TITLE
feat(layout): expose default column display mode

### DIFF
--- a/nirimod/column_display.py
+++ b/nirimod/column_display.py
@@ -1,0 +1,51 @@
+"""Shared helpers for Niri column display config values."""
+
+from __future__ import annotations
+
+
+COLUMN_DISPLAY_OPTIONS = [
+    ("Normal", "normal"),
+    ("Tabbed", "tabbed"),
+]
+COLUMN_DISPLAY_LABELS = [label for label, _ in COLUMN_DISPLAY_OPTIONS]
+COLUMN_DISPLAY_RULE_LABELS = ["Use Layout Default", *COLUMN_DISPLAY_LABELS]
+
+
+def normalize_column_display(value) -> str | None:
+    normalized = str(value or "").lower()
+    for _, option_value in COLUMN_DISPLAY_OPTIONS:
+        if normalized == option_value:
+            return option_value
+    return None
+
+
+def column_display_index(value) -> int:
+    normalized = normalize_column_display(value)
+    for index, (_, option_value) in enumerate(COLUMN_DISPLAY_OPTIONS):
+        if normalized == option_value:
+            return index
+    return 0
+
+
+def column_display_value(index: int) -> str:
+    if 0 <= index < len(COLUMN_DISPLAY_OPTIONS):
+        return COLUMN_DISPLAY_OPTIONS[index][1]
+    return COLUMN_DISPLAY_OPTIONS[0][1]
+
+
+def column_display_rule_index(value: str | None) -> int:
+    normalized = normalize_column_display(value)
+    if normalized is None:
+        return 0
+
+    for index, (_, option_value) in enumerate(COLUMN_DISPLAY_OPTIONS, start=1):
+        if normalized == option_value:
+            return index
+    return 0
+
+
+def column_display_rule_value(index: int) -> str | None:
+    option_index = index - 1
+    if not (0 <= option_index < len(COLUMN_DISPLAY_OPTIONS)):
+        return None
+    return COLUMN_DISPLAY_OPTIONS[option_index][1]

--- a/nirimod/pages/layout.py
+++ b/nirimod/pages/layout.py
@@ -10,6 +10,11 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gtk
 
 from nirimod.kdl_parser import KdlNode, find_or_create, set_child_arg, remove_child
+from nirimod.column_display import (
+    COLUMN_DISPLAY_LABELS,
+    column_display_index,
+    column_display_value,
+)
 from nirimod.pages.base import BasePage
 
 
@@ -57,6 +62,23 @@ class LayoutPage(BasePage):
             ),
         )
         basic_grp.add(cfc_row)
+
+        display_model = Gtk.StringList.new(COLUMN_DISPLAY_LABELS)
+        display_row = Adw.ComboRow(
+            title="Default Column Display",
+            subtitle="How new columns open",
+            model=display_model,
+        )
+        display_row.set_selected(
+            column_display_index(layout.child_arg("default-column-display"))
+        )
+        display_row.connect(
+            "notify::selected",
+            lambda r, _: self._set_layout(
+                "default-column-display", column_display_value(r.get_selected())
+            ),
+        )
+        basic_grp.add(display_row)
 
         prefer_csd_row = Adw.SwitchRow(
             title="Prefer No CSD", subtitle="Ask apps to omit client-side decorations"

--- a/nirimod/pages/window_rules.py
+++ b/nirimod/pages/window_rules.py
@@ -10,6 +10,12 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 from gi.repository import Adw, Gtk, GLib
 
+from nirimod.column_display import (
+    COLUMN_DISPLAY_RULE_LABELS,
+    column_display_rule_index,
+    column_display_rule_value,
+    normalize_column_display,
+)
 from nirimod.kdl_parser import KdlNode, KdlRawString
 from nirimod.pages.base import BasePage
 
@@ -163,6 +169,27 @@ def _floating_position_location_index(x: int, y: int, relative_to: str) -> int:
     return CUSTOM_FLOATING_POSITION_INDEX
 
 
+def _column_display_setting(rule: KdlNode | None) -> str | None:
+    if rule is None:
+        return None
+
+    node = rule.get_child("default-column-display")
+    if node is None or not node.args:
+        return None
+
+    return normalize_column_display(node.args[0])
+
+
+def _make_column_display_node(index: int) -> KdlNode | None:
+    value = column_display_rule_value(index)
+    if value is None:
+        return None
+    return KdlNode(
+        "default-column-display",
+        args=[value],
+    )
+
+
 def _legacy_size_arg_setting(value) -> tuple[str, float | int | None]:
     if isinstance(value, str):
         text = value.strip().rstrip(";")
@@ -266,6 +293,8 @@ def _rule_summary(rule: KdlNode) -> tuple[str, str]:
             badges.append("fullscreen")
         elif c.name in ("clip-to-geometry", "geometry-corner-radius"):
             pass  # skip noisy ones
+        elif c.name == "default-column-display" and c.args:
+            badges.append(f"column display {c.args[0]}")
         else:
             badges.append(c.name.replace("-", " "))
 
@@ -650,6 +679,17 @@ class WindowRulesPage(BasePage):
             for key in WINDOW_SIZE_CONTROLS
         }
 
+        column_display_model = Gtk.StringList.new(COLUMN_DISPLAY_RULE_LABELS)
+        column_display_row = Adw.ComboRow(
+            title="Default Column Display",
+            subtitle="Columns created from matching windows",
+            model=column_display_model,
+        )
+        column_display_row.set_selected(
+            column_display_rule_index(_column_display_setting(rule))
+        )
+        layout_grp.add(column_display_row)
+
         bool_rows: dict[str, Adw.SwitchRow] = {}
         for key, label in BOOL_ACTION_LABELS.items():
             sr = Adw.SwitchRow(title=label)
@@ -776,6 +816,12 @@ class WindowRulesPage(BasePage):
                 cn = self._size_node_from_controls(key, controls)
                 if cn is not None:
                     new_rule.children.append(cn)
+
+            column_display_node = _make_column_display_node(
+                column_display_row.get_selected()
+            )
+            if column_display_node is not None:
+                new_rule.children.append(column_display_node)
 
             # floating position
             position_node = self._floating_position_node_from_controls(

--- a/tests/test_column_display.py
+++ b/tests/test_column_display.py
@@ -1,0 +1,49 @@
+"""Tests for Niri column display config helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from nirimod.column_display import (
+    COLUMN_DISPLAY_RULE_LABELS,
+    column_display_index,
+    column_display_rule_index,
+    column_display_rule_value,
+    column_display_value,
+    normalize_column_display,
+)
+from nirimod.kdl_parser import KdlNode, set_child_arg, write_kdl
+
+
+class TestColumnDisplay(unittest.TestCase):
+    def test_layout_display_reads_tabbed_value(self):
+        self.assertEqual(column_display_index("tabbed"), 1)
+        self.assertEqual(column_display_value(1), "tabbed")
+
+    def test_unknown_layout_display_defaults_to_normal(self):
+        self.assertEqual(normalize_column_display("sideways"), None)
+        self.assertEqual(column_display_index("sideways"), 0)
+        self.assertEqual(column_display_value(99), "normal")
+
+    def test_rule_display_supports_use_layout_default(self):
+        self.assertEqual(column_display_rule_index(None), 0)
+        self.assertEqual(column_display_rule_value(0), None)
+
+    def test_rule_display_maps_tabbed_selection(self):
+        selected = COLUMN_DISPLAY_RULE_LABELS.index("Tabbed")
+
+        self.assertEqual(column_display_rule_index("tabbed"), selected)
+        self.assertEqual(column_display_rule_value(selected), "tabbed")
+
+    def test_default_column_display_serializes_as_layout_string(self):
+        layout = KdlNode("layout")
+        set_child_arg(layout, "default-column-display", "tabbed")
+
+        out = write_kdl([layout])
+
+        self.assertIn('default-column-display "tabbed"', out)
+        self.assertNotIn("default-column-display tabbed", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -7,6 +7,10 @@ import pytest
 
 pytest.importorskip("gi")
 
+from nirimod.column_display import (
+    COLUMN_DISPLAY_RULE_LABELS,
+    column_display_rule_index,
+)
 from nirimod.kdl_parser import KdlNode, write_kdl
 from nirimod.pages.window_rules import (
     CUSTOM_FLOATING_POSITION_INDEX,
@@ -17,10 +21,13 @@ from nirimod.pages.window_rules import (
     SIZE_PERCENT_PRESETS,
     _bool_action_active,
     _bool_action_node,
+    _column_display_setting,
     _floating_position_location_index,
     _floating_position_setting,
+    _make_column_display_node,
     _make_floating_position_node,
     _make_size_node,
+    _rule_summary,
     _window_size_setting,
 )
 
@@ -103,6 +110,42 @@ class TestWindowRuleActions(unittest.TestCase):
                 False, 0, 0, DEFAULT_FLOATING_POSITION_RELATIVE_TO
             )
         )
+
+    def test_column_display_default_writes_no_override(self):
+        self.assertIsNone(_make_column_display_node(0))
+        self.assertIsNone(_make_column_display_node(99))
+
+    def test_column_display_reads_tabbed_rule(self):
+        rule = KdlNode(
+            "window-rule",
+            children=[KdlNode("default-column-display", args=["tabbed"])],
+        )
+
+        self.assertEqual(_column_display_setting(rule), "tabbed")
+        self.assertEqual(
+            column_display_rule_index(_column_display_setting(rule)),
+            COLUMN_DISPLAY_RULE_LABELS.index("Tabbed"),
+        )
+
+    def test_column_display_writes_valid_niri_syntax(self):
+        node = _make_column_display_node(COLUMN_DISPLAY_RULE_LABELS.index("Tabbed"))
+        out = write_kdl([KdlNode("window-rule", children=[node])])
+
+        self.assertIn('default-column-display "tabbed"', out)
+        self.assertNotIn("default-column-display tabbed", out)
+
+    def test_rule_summary_shows_column_display_value(self):
+        rule = KdlNode(
+            "window-rule",
+            children=[
+                KdlNode("match", props={"app-id": "org.example.App"}),
+                KdlNode("default-column-display", args=["tabbed"]),
+            ],
+        )
+
+        _, subtitle = _rule_summary(rule)
+
+        self.assertIn("column display tabbed", subtitle)
 
     def test_floating_position_locations_are_edges_plus_custom(self):
         self.assertEqual(


### PR DESCRIPTION
Adds controls for Niri's `default-column-display` setting in both the Layout page and window-rule editor, allowing columns to default to normal or tabbed display.