### PR TITLE
Fix fractional-scale output snapping

### DIFF
--- a/nirimod/pages/outputs.py
+++ b/nirimod/pages/outputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import gi
@@ -29,6 +30,24 @@ TRANSFORMS = [
     "flipped-180",
     "flipped-270",
 ]
+
+
+def _snap_axis_origin(
+    other_edge: float,
+    dragged_size: float,
+    dragged_at_start: bool,
+    other_at_start: bool,
+) -> int:
+    """Round a snapped origin without moving opposing edges into each other."""
+    if dragged_at_start:
+        if other_at_start:
+            return round(other_edge)
+        return math.ceil(other_edge)
+
+    origin = other_edge - dragged_size
+    if other_at_start:
+        return math.floor(origin)
+    return round(origin)
 
 
 class OutputsPage(BasePage):
@@ -358,19 +377,41 @@ class OutputsPage(BasePage):
             other_top    = other_y
             other_bottom = other_y + other_logical_h
 
-            for dragged_edge, is_left_edge in [(dragged_left, True), (dragged_right, False)]:
-                for other_edge in [other_left, other_right]:
+            for dragged_edge, is_left_edge in [
+                (dragged_left, True),
+                (dragged_right, False),
+            ]:
+                for other_edge, is_other_left_edge in [
+                    (other_left, True),
+                    (other_right, False),
+                ]:
                     dist = abs(dragged_edge - other_edge)
                     if dist < closest_x:
                         closest_x = dist
-                        snapped_x = other_edge if is_left_edge else other_edge - logical_w
+                        snapped_x = _snap_axis_origin(
+                            other_edge,
+                            logical_w,
+                            is_left_edge,
+                            is_other_left_edge,
+                        )
 
-            for dragged_edge, is_top_edge in [(dragged_top, True), (dragged_bottom, False)]:
-                for other_edge in [other_top, other_bottom]:
+            for dragged_edge, is_top_edge in [
+                (dragged_top, True),
+                (dragged_bottom, False),
+            ]:
+                for other_edge, is_other_top_edge in [
+                    (other_top, True),
+                    (other_bottom, False),
+                ]:
                     dist = abs(dragged_edge - other_edge)
                     if dist < closest_y:
                         closest_y = dist
-                        snapped_y = other_edge if is_top_edge else other_edge - logical_h
+                        snapped_y = _snap_axis_origin(
+                            other_edge,
+                            logical_h,
+                            is_top_edge,
+                            is_other_top_edge,
+                        )
 
         if closest_x <= SNAP_THRESHOLD:
             new_lx = snapped_x

--- a/nirimod/pages/outputs.py
+++ b/nirimod/pages/outputs.py
@@ -377,41 +377,52 @@ class OutputsPage(BasePage):
             other_top    = other_y
             other_bottom = other_y + other_logical_h
 
-            for dragged_edge, is_left_edge in [
-                (dragged_left, True),
-                (dragged_right, False),
-            ]:
-                for other_edge, is_other_left_edge in [
-                    (other_left, True),
-                    (other_right, False),
-                ]:
-                    dist = abs(dragged_edge - other_edge)
-                    if dist < closest_x:
-                        closest_x = dist
-                        snapped_x = _snap_axis_origin(
-                            other_edge,
-                            logical_w,
-                            is_left_edge,
-                            is_other_left_edge,
-                        )
+            vertical_spans_are_near = not (
+                dragged_bottom < other_top - SNAP_THRESHOLD
+                or other_bottom + SNAP_THRESHOLD < dragged_top
+            )
+            horizontal_spans_are_near = not (
+                dragged_right < other_left - SNAP_THRESHOLD
+                or other_right + SNAP_THRESHOLD < dragged_left
+            )
 
-            for dragged_edge, is_top_edge in [
-                (dragged_top, True),
-                (dragged_bottom, False),
-            ]:
-                for other_edge, is_other_top_edge in [
-                    (other_top, True),
-                    (other_bottom, False),
+            if vertical_spans_are_near:
+                for dragged_edge, is_left_edge in [
+                    (dragged_left, True),
+                    (dragged_right, False),
                 ]:
-                    dist = abs(dragged_edge - other_edge)
-                    if dist < closest_y:
-                        closest_y = dist
-                        snapped_y = _snap_axis_origin(
-                            other_edge,
-                            logical_h,
-                            is_top_edge,
-                            is_other_top_edge,
-                        )
+                    for other_edge, is_other_left_edge in [
+                        (other_left, True),
+                        (other_right, False),
+                    ]:
+                        dist = abs(dragged_edge - other_edge)
+                        if dist < closest_x:
+                            closest_x = dist
+                            snapped_x = _snap_axis_origin(
+                                other_edge,
+                                logical_w,
+                                is_left_edge,
+                                is_other_left_edge,
+                            )
+
+            if horizontal_spans_are_near:
+                for dragged_edge, is_top_edge in [
+                    (dragged_top, True),
+                    (dragged_bottom, False),
+                ]:
+                    for other_edge, is_other_top_edge in [
+                        (other_top, True),
+                        (other_bottom, False),
+                    ]:
+                        dist = abs(dragged_edge - other_edge)
+                        if dist < closest_y:
+                            closest_y = dist
+                            snapped_y = _snap_axis_origin(
+                                other_edge,
+                                logical_h,
+                                is_top_edge,
+                                is_other_top_edge,
+                            )
 
         if closest_x <= SNAP_THRESHOLD:
             new_lx = snapped_x

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,0 +1,79 @@
+"""Tests for output snapping."""
+
+from __future__ import annotations
+
+import unittest
+
+from nirimod.pages.outputs import OutputsPage
+
+
+def _output(name: str, x: int, y: int) -> dict:
+    width = 2560
+    height = 1440
+    scale = 1.1
+    return {
+        "name": name,
+        "modes": [{"width": width, "height": height, "refresh_rate": 59951}],
+        "current_mode": 0,
+        "logical": {
+            "x": x,
+            "y": y,
+            "width": round(width / scale),
+            "height": round(height / scale),
+            "scale": scale,
+            "transform": "normal",
+        },
+    }
+
+
+def _drag(outputs: list[dict], name: str, x: int, y: int) -> tuple[int, int]:
+    page = object.__new__(OutputsPage)
+    page._outputs = outputs
+    page._drag_output = name
+    page._drag_current_lx = x
+    page._drag_current_ly = y
+    page._drag_start_scale = 1
+    page._canvas_scale = 1
+    page._last_dx = 0
+    page._last_dy = 0
+    page._canvas = None
+
+    page._on_drag_update(None, 0, 0)
+
+    dragged = next(output for output in outputs if output["name"] == name)
+    position = dragged["logical"]
+    return position["x"], position["y"]
+
+
+class TestOutputSnapping(unittest.TestCase):
+    def test_snap_right_rounds_outward(self):
+        outputs = [_output("left", 1652, -32), _output("right", 3975, -32)]
+
+        x, _ = _drag(outputs, "right", 3975, -32)
+
+        self.assertEqual(x, 3980)
+
+    def test_snap_left_rounds_outward(self):
+        outputs = [_output("left", 1655, -32), _output("right", 3980, -32)]
+
+        x, _ = _drag(outputs, "left", 1655, -32)
+
+        self.assertEqual(x, 1652)
+
+    def test_snap_below_rounds_outward(self):
+        outputs = [_output("top", 0, 0), _output("bottom", 0, 1305)]
+
+        _, y = _drag(outputs, "bottom", 0, 1305)
+
+        self.assertEqual(y, 1310)
+
+    def test_snap_above_rounds_outward(self):
+        outputs = [_output("top", 0, -1305), _output("bottom", 0, 0)]
+
+        _, y = _drag(outputs, "top", 0, -1305)
+
+        self.assertEqual(y, -1310)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import math
 import unittest
 
+import pytest
+
+pytest.importorskip("gi")
+
 from nirimod.pages.outputs import OutputsPage
 
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import math
 import unittest
 
 from nirimod.pages.outputs import OutputsPage
 
 
-def _output(name: str, x: int, y: int) -> dict:
-    width = 2560
-    height = 1440
-    scale = 1.1
+def _output(
+    name: str,
+    x: float,
+    y: float,
+    width: int = 2560,
+    height: int = 1440,
+    scale: float = 1.1,
+    transform: str = "normal",
+) -> dict:
+    logical_width = width / scale
+    logical_height = height / scale
+    if transform in ["90", "270", "flipped-90", "flipped-270"]:
+        logical_width, logical_height = logical_height, logical_width
+
     return {
         "name": name,
         "modes": [{"width": width, "height": height, "refresh_rate": 59951}],
@@ -18,15 +29,42 @@ def _output(name: str, x: int, y: int) -> dict:
         "logical": {
             "x": x,
             "y": y,
-            "width": round(width / scale),
-            "height": round(height / scale),
+            "width": round(logical_width),
+            "height": round(logical_height),
             "scale": scale,
-            "transform": "normal",
+            "transform": transform,
         },
     }
 
 
-def _drag(outputs: list[dict], name: str, x: int, y: int) -> tuple[int, int]:
+def _logical_size(output: dict) -> tuple[float, float]:
+    mode = output["modes"][output["current_mode"]]
+    width = mode["width"]
+    height = mode["height"]
+    transform = output["logical"]["transform"]
+    if transform in ["90", "270", "flipped-90", "flipped-270"]:
+        width, height = height, width
+    scale = output["logical"]["scale"]
+    return width / scale, height / scale
+
+
+def _overlaps(first: dict, second: dict) -> bool:
+    first_width, first_height = _logical_size(first)
+    second_width, second_height = _logical_size(second)
+    first_x = first["logical"]["x"]
+    first_y = first["logical"]["y"]
+    second_x = second["logical"]["x"]
+    second_y = second["logical"]["y"]
+
+    return not (
+        first_x + math.ceil(first_width) <= second_x
+        or second_x + math.ceil(second_width) <= first_x
+        or first_y + math.ceil(first_height) <= second_y
+        or second_y + math.ceil(second_height) <= first_y
+    )
+
+
+def _drag(outputs: list[dict], name: str, x: float, y: float) -> tuple[float, float]:
     page = object.__new__(OutputsPage)
     page._outputs = outputs
     page._drag_output = name
@@ -73,6 +111,94 @@ class TestOutputSnapping(unittest.TestCase):
         _, y = _drag(outputs, "top", 0, -1305)
 
         self.assertEqual(y, -1310)
+
+    def test_distant_output_does_not_supply_x_snap(self):
+        exact_width = 2560 / 1.1
+        upper = _output("upper", 0, 0)
+        right = _output("right", 4655, 2000)
+        dragged = _output("dragged", exact_width, 2000)
+        outputs = [upper, right, dragged]
+
+        position = _drag(outputs, "dragged", exact_width, 2000)
+
+        self.assertEqual(position, (2327, 2000))
+        self.assertFalse(_overlaps(dragged, upper))
+        self.assertFalse(_overlaps(dragged, right))
+
+    def test_distant_output_does_not_supply_y_snap(self):
+        exact_height = 1440 / 1.1
+        left = _output("left", 0, 0)
+        below = _output("below", 3000, 2619)
+        dragged = _output("dragged", 3000, exact_height)
+        outputs = [left, below, dragged]
+
+        position = _drag(outputs, "dragged", 3000, exact_height)
+
+        self.assertEqual(position, (3000, 1309))
+        self.assertFalse(_overlaps(dragged, left))
+        self.assertFalse(_overlaps(dragged, below))
+
+    def test_snap_left_of_vertical_stack_at_each_row(self):
+        row_height = math.ceil(1440 / 1.1)
+
+        for row in range(3):
+            with self.subTest(row=row):
+                stack = [
+                    _output(f"stack-{index}", 0, index * row_height)
+                    for index in range(3)
+                ]
+                dragged = _output("dragged", -2325, row * row_height)
+                outputs = [*stack, dragged]
+
+                position = _drag(outputs, "dragged", -2325, row * row_height)
+
+                self.assertEqual(position, (-2328, row * row_height))
+                self.assertTrue(all(not _overlaps(dragged, output) for output in stack))
+
+    def test_snap_above_horizontal_row_at_each_column(self):
+        column_width = math.ceil(2560 / 1.1)
+
+        for column in range(3):
+            with self.subTest(column=column):
+                row = [
+                    _output(f"row-{index}", index * column_width, 0)
+                    for index in range(3)
+                ]
+                dragged = _output("dragged", column * column_width, -1305)
+                outputs = [*row, dragged]
+
+                position = _drag(outputs, "dragged", column * column_width, -1305)
+
+                self.assertEqual(position, (column * column_width, -1310))
+                self.assertTrue(all(not _overlaps(dragged, output) for output in row))
+
+    def test_snap_into_open_corner_of_l_shaped_layout(self):
+        top_left = _output("top-left", 0, 0)
+        top_right = _output("top-right", 2328, 0)
+        bottom_left = _output("bottom-left", 0, 1310)
+        dragged = _output("dragged", 2325, 1305)
+        existing = [top_left, top_right, bottom_left]
+
+        position = _drag([*existing, dragged], "dragged", 2325, 1305)
+
+        self.assertEqual(position, (2328, 1310))
+        self.assertTrue(all(not _overlaps(dragged, output) for output in existing))
+
+    def test_snap_right_of_negative_mixed_scale_output(self):
+        laptop = _output(
+            "laptop",
+            -114,
+            65,
+            width=2560,
+            height=1600,
+            scale=1.45,
+        )
+        dragged = _output("dragged", 1648, -32)
+
+        position = _drag([laptop, dragged], "dragged", 1648, -32)
+
+        self.assertEqual(position, (1652, -32))
+        self.assertFalse(_overlaps(dragged, laptop))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At fractional scales, an output's exact logical edge does not always land on an integer: #39. NiriMod calculated that edge while dragging, then used ordinary rounding when writing the position. This can round toward the neighboring output, leaving a small overlap that makes Niri discard the requested position and fall back to automatic placement.

This rounds opposing-edge snaps outward instead: up for right/bottom placement and down for left/top placement. Same-edge alignment keeps normal rounding.

While testing layouts with more than two displays, I found that X and Y could also choose edges from unrelated outputs. X candidates are now limited to outputs with nearby vertical spans, and Y candidates to outputs with nearby horizontal spans. This prevents a snap in one axis from creating an overlap with a different display in staggered or multi-row layouts.

The tests cover all four directions, the unrelated-axis regression, three-display rows and stacks, an L-shaped layout, and mixed-scale negative coordinates. They follow the existing GTK test guard and skip cleanly when `gi` is unavailable.

Validation: `uv run pytest` passes 126 tests and 6 subtests; Ruff lint passes for the changed files, however `main` is currently not formatted according to the contributing guidelines, I left the rest untouched but consider adding a workflow for this, I'll open an issue to track.

Closes #39 