### PR TITLE
Fix symlinked config saves

### DIFF
--- a/nirimod/kdl_parser.py
+++ b/nirimod/kdl_parser.py
@@ -8,6 +8,7 @@ find/replace rather than a full AST round-trip.
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -494,9 +495,15 @@ def _atomic_write(path: Path, content: str) -> None:
     if target.exists() and target.read_text() == content:
         return
     target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target_mode = stat.S_IMODE(target.stat().st_mode)
+    except FileNotFoundError:
+        target_mode = None
     fd, tmp = tempfile.mkstemp(dir=target.parent, prefix=".nirimod_tmp_")
     try:
         os.write(fd, content.encode())
+        if target_mode is not None:
+            os.fchmod(fd, target_mode)
         os.close(fd)
         fd = -1
         os.replace(tmp, target)

--- a/nirimod/kdl_parser.py
+++ b/nirimod/kdl_parser.py
@@ -483,16 +483,23 @@ def load_niri_config_multi() -> tuple[list[KdlNode], list[tuple[KdlNode, Path]]]
     return _resolve_includes(raw, NIRI_CONFIG)
 
 
+def _write_target(path: Path) -> Path:
+    if path.is_symlink():
+        return path.resolve(strict=False)
+    return path
+
+
 def _atomic_write(path: Path, content: str) -> None:
-    if path.exists() and path.read_text() == content:
+    target = _write_target(path)
+    if target.exists() and target.read_text() == content:
         return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".nirimod_tmp_")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=target.parent, prefix=".nirimod_tmp_")
     try:
         os.write(fd, content.encode())
         os.close(fd)
         fd = -1
-        os.replace(tmp, path)
+        os.replace(tmp, target)
     except Exception:
         if fd != -1:
             os.close(fd)
@@ -501,6 +508,12 @@ def _atomic_write(path: Path, content: str) -> None:
         except OSError:
             pass
         raise
+
+
+def replace_config_file(source: Path, destination: Path) -> None:
+    """Replace a config file without replacing a destination symlink."""
+    _atomic_write(destination, source.read_text())
+    source.unlink()
 
 
 def save_niri_config_multi(

--- a/nirimod/pages/raw_config.py
+++ b/nirimod/pages/raw_config.py
@@ -12,7 +12,7 @@ from gi.repository import Gtk, Pango, GLib
 from pathlib import Path
 
 from nirimod import niri_ipc
-from nirimod.kdl_parser import NIRI_CONFIG
+from nirimod.kdl_parser import NIRI_CONFIG, replace_config_file
 from nirimod.pages.base import BasePage
 
 
@@ -225,7 +225,7 @@ class RawConfigPage(BasePage):
                 self.show_toast(f"Validation error: {msg[:120]}", timeout=8)
                 return
             try:
-                tmp.replace(path)
+                replace_config_file(tmp, path)
             except Exception as e:
                 self.show_toast(f"Save error: {e}", timeout=6)
                 return

--- a/nirimod/window.py
+++ b/nirimod/window.py
@@ -613,7 +613,7 @@ class NiriModWindow(Adw.ApplicationWindow):
                     self.show_toast(f"Validation error: {msg}", timeout=8)
                     tmp_kdl.unlink(missing_ok=True)
                     return
-                shutil.move(tmp_kdl, kdl_parser.NIRI_CONFIG)
+                kdl_parser.replace_config_file(tmp_kdl, kdl_parser.NIRI_CONFIG)
                 niri_ipc.run_in_thread(niri_ipc.load_config_file, _finish_save)
 
             niri_ipc.run_in_thread(

--- a/tests/test_kdl_parser.py
+++ b/tests/test_kdl_parser.py
@@ -7,13 +7,21 @@ all config changes in NiriMod.
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
+from nirimod import kdl_parser
 from nirimod.kdl_parser import (
     KdlNode,
     KdlRawString,
     find_or_create,
+    load_niri_config_multi,
     parse_kdl,
     remove_child,
+    replace_config_file,
+    save_niri_config,
+    save_niri_config_multi,
     set_child_arg,
     set_node_flag,
     write_kdl,
@@ -196,6 +204,78 @@ class TestWriteKdl(unittest.TestCase):
         out = write_kdl([parent])
         self.assertIn("gaps", out)
         self.assertIn("16", out)
+
+
+class TestConfigWrites(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.managed_dir = self.root / "managed"
+        self.active_dir = self.root / "active"
+        self.managed_dir.mkdir()
+        self.active_dir.mkdir()
+
+    def _link(self, name: str, content: str | None = None) -> tuple[Path, Path]:
+        target = self.managed_dir / name
+        if content is not None:
+            target.write_text(content)
+        link = self.active_dir / name
+        link.symlink_to(Path("..") / "managed" / name)
+        return link, target
+
+    def test_save_updates_regular_file(self):
+        config = self.active_dir / "config.kdl"
+        config.write_text("gaps 4\n")
+
+        save_niri_config(parse_kdl("gaps 8\n"), path=config)
+
+        self.assertFalse(config.is_symlink())
+        self.assertEqual(config.read_text(), "gaps 8\n")
+
+    def test_save_preserves_symlink_and_updates_target(self):
+        link, target = self._link("config.kdl", "gaps 4\n")
+
+        save_niri_config(parse_kdl("gaps 8\n"), path=link)
+
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(target.read_text(), "gaps 8\n")
+
+    def test_save_preserves_broken_symlink_and_creates_target(self):
+        link, target = self._link("config.kdl")
+
+        save_niri_config(parse_kdl("gaps 8\n"), path=link)
+
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(target.read_text(), "gaps 8\n")
+
+    def test_validated_replacement_preserves_symlink(self):
+        link, target = self._link("config.kdl", "gaps 4\n")
+        validated = self.active_dir / ".config.kdl.tmp"
+        validated.write_text("gaps 8\n")
+
+        replace_config_file(validated, link)
+
+        self.assertTrue(link.is_symlink())
+        self.assertFalse(validated.exists())
+        self.assertEqual(target.read_text(), "gaps 8\n")
+
+    def test_multi_file_save_preserves_primary_and_include_symlinks(self):
+        config_link, config_target = self._link(
+            "config.kdl", 'include "local.kdl"\nprefer-no-csd\n'
+        )
+        local_link, local_target = self._link("local.kdl", 'spawn-at-startup "old"\n')
+
+        with patch.object(kdl_parser, "NIRI_CONFIG", config_link):
+            nodes, include_slots = load_niri_config_multi()
+            startup = next(node for node in nodes if node.name == "spawn-at-startup")
+            startup.args[0] = "new"
+            save_niri_config_multi(nodes, include_slots)
+
+        self.assertTrue(config_link.is_symlink())
+        self.assertTrue(local_link.is_symlink())
+        self.assertIn('include "local.kdl"', config_target.read_text())
+        self.assertIn('spawn-at-startup "new"', local_target.read_text())
 
 
 if __name__ == "__main__":

--- a/tests/test_kdl_parser.py
+++ b/tests/test_kdl_parser.py
@@ -6,6 +6,7 @@ all config changes in NiriMod.
 
 from __future__ import annotations
 
+import stat
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -227,19 +228,32 @@ class TestConfigWrites(unittest.TestCase):
     def test_save_updates_regular_file(self):
         config = self.active_dir / "config.kdl"
         config.write_text("gaps 4\n")
+        config.chmod(0o640)
 
         save_niri_config(parse_kdl("gaps 8\n"), path=config)
 
         self.assertFalse(config.is_symlink())
         self.assertEqual(config.read_text(), "gaps 8\n")
+        self.assertEqual(stat.S_IMODE(config.stat().st_mode), 0o640)
+
+    def test_save_preserves_special_mode_bits(self):
+        config = self.active_dir / "config.kdl"
+        config.write_text("gaps 4\n")
+        config.chmod(0o6750)
+
+        save_niri_config(parse_kdl("gaps 8\n"), path=config)
+
+        self.assertEqual(stat.S_IMODE(config.stat().st_mode), 0o6750)
 
     def test_save_preserves_symlink_and_updates_target(self):
         link, target = self._link("config.kdl", "gaps 4\n")
+        target.chmod(0o640)
 
         save_niri_config(parse_kdl("gaps 8\n"), path=link)
 
         self.assertTrue(link.is_symlink())
         self.assertEqual(target.read_text(), "gaps 8\n")
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o640)
 
     def test_save_preserves_broken_symlink_and_creates_target(self):
         link, target = self._link("config.kdl")
@@ -248,9 +262,11 @@ class TestConfigWrites(unittest.TestCase):
 
         self.assertTrue(link.is_symlink())
         self.assertEqual(target.read_text(), "gaps 8\n")
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o600)
 
     def test_validated_replacement_preserves_symlink(self):
         link, target = self._link("config.kdl", "gaps 4\n")
+        target.chmod(0o640)
         validated = self.active_dir / ".config.kdl.tmp"
         validated.write_text("gaps 8\n")
 
@@ -259,6 +275,7 @@ class TestConfigWrites(unittest.TestCase):
         self.assertTrue(link.is_symlink())
         self.assertFalse(validated.exists())
         self.assertEqual(target.read_text(), "gaps 8\n")
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o640)
 
     def test_multi_file_save_preserves_primary_and_include_symlinks(self):
         config_link, config_target = self._link(


### PR DESCRIPTION
NiriMod saves configs through temporary files and atomically replaces the configured path. When `config.kdl` or an included file is a symlink, that replacement overwrites the link instead of updating its target, breaking symlink-managed dotfile setups: #36. Replacing an existing file also carries over the temporary file's `0600` mode, silently changing its access permissions.

I use symlinks to track my dotfiles and manage those with git so I figured I'd give improving this a go. Nirimod already handles imported config files (e.g. `include "local.kdl"`) perfectly, this PR extends this mode of operation to respect existing setup also for symlinks.

The approach taken is to resolve symlinks only when choosing the final write destination, then create and replace the temporary file beside the target. The configured symlink stays in place, while the target is still updated atomically. Existing mode bits are retained, and normal saves and the Raw Config editor now use the same replacement helper.

Tests cover regular files, existing and broken relative symlinks, validated temporary-file replacement, multi-file configs with symlinked primary and included files, and permission preservation across the write paths.

Validation: `uv run pytest` passes 122 tests; Ruff lint passes for the changed files. Main is still not formatted (#41), I left the existing badly formatted files alone so merging is cleaner.

Closes #36