### PR TITLE
fix: preserve comment-only KDL blocks

### DIFF
--- a/nirimod/kdl_parser.py
+++ b/nirimod/kdl_parser.py
@@ -56,6 +56,7 @@ class KdlNode:
     args: list[Any] = field(default_factory=list)
     props: dict[str, Any] = field(default_factory=dict)
     children: list["KdlNode"] = field(default_factory=list)
+    has_block: bool = False
     leading_trivia: str = ""
     trailing_trivia: str = ""
     children_trailing_trivia: str = ""
@@ -343,6 +344,7 @@ def _parse_nodes(
                 node.trailing_trivia += accumulated_ws
                 accumulated_ws = ""
                 pos += 1
+                node.has_block = True
                 node.children, pos, node.children_trailing_trivia = _parse_nodes(
                     tokens, pos
                 )
@@ -650,7 +652,7 @@ def _write_node(node: KdlNode, indent: int = 0) -> str:
 
     res += " ".join(parts)
 
-    if node.children:
+    if node.children or node.has_block:
         if _is_inline_node(node):
             pre_brace = node.trailing_trivia if node.trailing_trivia else " "
             if not pre_brace[0].isspace():

--- a/tests/test_kdl_parser.py
+++ b/tests/test_kdl_parser.py
@@ -101,6 +101,22 @@ class TestKdlRoundTrip(unittest.TestCase):
         out = write_kdl(parse_kdl(src))
         self.assertIn("prefer-no-csd", out)
 
+    def test_comment_only_child_block_preserves_braces(self):
+        src = "xkb {\n    // keep this keyboard note\n}\nafter-node\n"
+        nodes = parse_kdl(src)
+
+        self.assertTrue(nodes[0].has_block)
+        self.assertEqual(nodes[0].children, [])
+
+        out = write_kdl(nodes)
+        self.assertIn("xkb {", out)
+        self.assertIn("// keep this keyboard note", out)
+        self.assertIn("}\nafter-node", out)
+
+        roundtripped = parse_kdl(out)
+        self.assertTrue(roundtripped[0].has_block)
+        self.assertEqual(roundtripped[0].children, [])
+
 
 class TestMutationHelpers(unittest.TestCase):
     """Tests for find_or_create, set_child_arg, remove_child, set_node_flag."""


### PR DESCRIPTION
## Summary

- preserve whether a parsed node had a block, even when the block contains only comments
- use that block marker when serializing so comment-only blocks keep their braces
- add a round-trip regression test for a comment-only block followed by another node

Closes #43.

## Validation

- `python -m unittest discover -s tests -p 'test_kdl_parser.py' -v`: 28 passed; 5 existing Windows mode-bit failures in config-write tests (`0o600`/`0o640`/`0o6750` assertions)
- focused comment-only block reproduction passes
- `python -m ruff format --check nirimod/kdl_parser.py tests/test_kdl_parser.py` passes
- `git diff --check` passes
- targeted Ruff reports only three pre-existing E501 findings in unchanged lines

The change is limited to the parser state and its regression coverage. Let me know what you think.